### PR TITLE
Update manifest base image docs

### DIFF
--- a/docs/em/manifest.md
+++ b/docs/em/manifest.md
@@ -25,7 +25,7 @@ resources:
       disk_spec:
         kind: "root_disk"
         size: 10
-        image: "{{ base_image_url | default('https://repo.exordos.com/exordos-base/0.4.1/exordos-base.raw.gz') }}"
+        image: "{{ base_image_url | default('https://repo.exordos.com/exordos-base/1.1.0/exordos-base.raw.zst') }}"
   
   $core.em.services:
     example_service:

--- a/docs/em/manifest.ru.md
+++ b/docs/em/manifest.ru.md
@@ -25,7 +25,7 @@ resources:
       disk_spec:
         kind: "root_disk"
         size: 10
-        image: "{{ base_image_url | default('https://repo.exordos.com/exordos-base/0.4.1/exordos-base.raw.gz') }}"
+        image: "{{ base_image_url | default('https://repo.exordos.com/exordos-base/1.1.0/exordos-base.raw.zst') }}"
   
   $core.em.services:
     example_service:


### PR DESCRIPTION
## Summary
- Update manifest examples to use the current exordos-base image URL.
- Keep English and Russian documentation examples in sync.

## Why
The old documented image URL returns 404. The replacement `https://repo.exordos.com/exordos-base/1.1.0/exordos-base.raw.zst` is already used by repository manifest examples/tests and was verified by launching a smoke VM through the platform.

## Validation
- Checked repository references for the current documented exordos-base image.
- Verified image URL availability with an HTTP HEAD request.
- Launched a test VM via `exordos cn add --wait` using the updated image and observed it reach ACTIVE.