### PR TITLE
fix(drivers): LibvirtPoolDriver interface-type selection

### DIFF
--- a/exordos_core/compute/constants.py
+++ b/exordos_core/compute/constants.py
@@ -26,6 +26,11 @@ POLICY_SERVICE_NAME = "compute"
 
 NODE_SET_PROJECT = sys_uuid.UUID("11111113-bc70-4760-9fbf-9fcfe40da329")
 
+# Sentinel UUID for the transient boot-network port (see
+# Port.from_boot_network()) - a real UUID doesn't make sense for it since
+# it's replaced once the machine is flashed.
+BOOT_NETWORK_PORT_UUID = sys_uuid.UUID("00000000-0000-0000-0000-000000000000")
+
 
 BootType = tp.Literal["hd", "network", "cdrom"]
 

--- a/exordos_core/compute/dm/models.py
+++ b/exordos_core/compute/dm/models.py
@@ -769,9 +769,9 @@ class Port(cm.ModelWithFullAsset, orm.SQLStorableMixin, models.SimpleViewMixin):
             }
         )
         return cls(
-            # The UUID is not important for port in boot network.
-            # It is just a placeholder.
-            uuid=sys_uuid.UUID("00000000-0000-0000-0000-000000000000"),
+            # The pool driver relies on this specific UUID to recognize the
+            # port as the transient boot network (see LibvirtPoolDriver).
+            uuid=nc.BOOT_NETWORK_PORT_UUID,
             project_id=cc.SERVICE_PROJECT_ID,
             name="bootnet_port",
             subnet=boot_subnet.uuid,

--- a/exordos_core/compute/pool/drivers/libvirt.py
+++ b/exordos_core/compute/pool/drivers/libvirt.py
@@ -41,6 +41,25 @@ MAX_VOLUME_INDEX = 4096
 CONSOLE_LOG_DIR = "/var/log/libvirt/qemu"
 
 
+def _interface_source(
+    iface: ET.Element, source_el: tp.Optional[ET.Element]
+) -> tp.Optional[str]:
+    """Return the logical network/bridge name this interface connects to.
+
+    A domain interface created as type='network' backed by a libvirt
+    network with <forward mode='bridge'/> gets rewritten by libvirt in
+    the live/persistent XML to type='bridge', but its <source> element
+    keeps both the original 'network' attribute (the logical name the
+    orchestrator/target state actually tracks) and the 'bridge' one
+    (the real underlying device). Prefer 'network' when present so a
+    boot port riding such a network still reports its logical name
+    instead of the bridge it happens to be implemented with.
+    """
+    if source_el is None:
+        return None
+    return source_el.get("network") or source_el.get(iface.get("type"))
+
+
 class StoragePoolType(enum.Enum):
     DIR = "dir"
     ZFS = "zfs"
@@ -621,11 +640,7 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
             mac_el = iface.find("mac")
             source_el = iface.find("source")
             mac = mac_el.get("address")
-            # The boot-network port is always type='network' regardless of
-            # the hypervisor's own network_type (see create_machine) - read
-            # the source attribute this specific interface actually has
-            # ('network' or 'bridge'), not the hypervisor's configured type.
-            source = source_el.get(iface.get("type"))
+            source = _interface_source(iface, source_el)
 
             if not mac or not source:
                 raise ValueError(f"Interface {iface} has no mac or source")
@@ -704,9 +719,7 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
             mac_el = iface.find("mac")
             source_el = iface.find("source")
             mac = mac_el.get("address")
-            # See _domain2machine: read the source attribute this specific
-            # interface actually has, not the hypervisor's network_type.
-            source = source_el.get(iface.get("type"))
+            source = _interface_source(iface, source_el)
 
             if not mac or not source:
                 raise ValueError(f"Interface {iface} has no mac or source")

--- a/exordos_core/compute/pool/drivers/libvirt.py
+++ b/exordos_core/compute/pool/drivers/libvirt.py
@@ -1198,13 +1198,8 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
             raise
 
         # Build interface XML
-        # Always type='network': `port.source` is the logical libvirt
-        # network name the orchestrator tracks (see create_machine), not
-        # necessarily a literal host bridge device - a bridge-type
-        # hypervisor still needs it resolved through a local libvirt
-        # network that forwards onto the real bridge.
         interface_xml = XMLLibvirtInstance.interface_xml(
-            iface_type="network",
+            iface_type=self._spec.network_type,
             mac=port.mac,
             rom=self._spec.iface_rom_file,
             mtu=self._spec.iface_mtu,
@@ -1303,12 +1298,17 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
                 mac=port.mac,
                 rom=self._spec.iface_rom_file,
                 mtu=self._spec.iface_mtu,
-                # Always type='network': `port.source` is a logical
-                # libvirt network name the orchestrator tracks (the boot
-                # network at initial creation, or the main network when
-                # recreate_machine() rebuilds the domain post-flash), not
-                # necessarily a literal host bridge device.
-                iface_type="network",
+                # The boot-network port (see Port.from_boot_network()) is
+                # always a transient libvirt-managed network, regardless of
+                # the hypervisor's own network_type - unlike the real
+                # port(s) attached once the machine is flashed
+                # (recreate_machine()), which must honor it (e.g. a raw
+                # host bridge on bridge-type hypervisors).
+                iface_type=(
+                    "network"
+                    if port.uuid == nc.BOOT_NETWORK_PORT_UUID
+                    else self._spec.network_type
+                ),
                 source=port.source,
             )
 

--- a/exordos_core/compute/pool/drivers/libvirt.py
+++ b/exordos_core/compute/pool/drivers/libvirt.py
@@ -724,9 +724,24 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
             if not mac or not source:
                 raise ValueError(f"Interface {iface} has no mac or source")
 
+            # A <source network=...> attribute only ever appears on an
+            # interface create_machine() built with iface_type='network' -
+            # i.e. the transient boot port (see Port.from_boot_network()),
+            # which create_machine() always makes type='network' regardless
+            # of the hypervisor's own network_type. A real bridge-type
+            # interface's <source> only ever carries a 'bridge' attribute.
+            # Reuse that distinction (rather than reusing the boot port's
+            # sentinel UUID for every reconstructed port) so a real port
+            # round-trips through create_machine() with its own type intact.
+            port_uuid = (
+                nc.BOOT_NETWORK_PORT_UUID
+                if source_el is not None and source_el.get("network") is not None
+                else sys_uuid.uuid4()
+            )
+
             ports.append(
                 models.Port(
-                    uuid=sys_uuid.UUID("00000000-0000-0000-0000-000000000000"),
+                    uuid=port_uuid,
                     machine=machine.uuid,
                     mac=mac,
                     project_id=c.SERVICE_PROJECT_ID,

--- a/exordos_core/compute/pool/drivers/libvirt.py
+++ b/exordos_core/compute/pool/drivers/libvirt.py
@@ -1198,8 +1198,13 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
             raise
 
         # Build interface XML
+        # Always type='network': `port.source` is the logical libvirt
+        # network name the orchestrator tracks (see create_machine), not
+        # necessarily a literal host bridge device - a bridge-type
+        # hypervisor still needs it resolved through a local libvirt
+        # network that forwards onto the real bridge.
         interface_xml = XMLLibvirtInstance.interface_xml(
-            iface_type=self._spec.network_type,
+            iface_type="network",
             mac=port.mac,
             rom=self._spec.iface_rom_file,
             mtu=self._spec.iface_mtu,
@@ -1298,12 +1303,11 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
                 mac=port.mac,
                 rom=self._spec.iface_rom_file,
                 mtu=self._spec.iface_mtu,
-                # The port a machine is created with is always the transient
-                # boot network (see pool.py's MetaMachine.dump_to_dp), which
-                # is always a plain libvirt virtual network - never the
-                # hypervisor's own (possibly bridge-type) main network. The
-                # real port replaces it later via attach_port(), which does
-                # use self._spec.network_type.
+                # Always type='network': `port.source` is a logical
+                # libvirt network name the orchestrator tracks (the boot
+                # network at initial creation, or the main network when
+                # recreate_machine() rebuilds the domain post-flash), not
+                # necessarily a literal host bridge device.
                 iface_type="network",
                 source=port.source,
             )

--- a/exordos_core/compute/pool/drivers/libvirt.py
+++ b/exordos_core/compute/pool/drivers/libvirt.py
@@ -621,7 +621,11 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
             mac_el = iface.find("mac")
             source_el = iface.find("source")
             mac = mac_el.get("address")
-            source = source_el.get(self._spec.network_type)
+            # The boot-network port is always type='network' regardless of
+            # the hypervisor's own network_type (see create_machine) - read
+            # the source attribute this specific interface actually has
+            # ('network' or 'bridge'), not the hypervisor's configured type.
+            source = source_el.get(iface.get("type"))
 
             if not mac or not source:
                 raise ValueError(f"Interface {iface} has no mac or source")
@@ -700,7 +704,9 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
             mac_el = iface.find("mac")
             source_el = iface.find("source")
             mac = mac_el.get("address")
-            source = source_el.get(self._spec.network_type)
+            # See _domain2machine: read the source attribute this specific
+            # interface actually has, not the hypervisor's network_type.
+            source = source_el.get(iface.get("type"))
 
             if not mac or not source:
                 raise ValueError(f"Interface {iface} has no mac or source")

--- a/exordos_core/compute/pool/drivers/libvirt.py
+++ b/exordos_core/compute/pool/drivers/libvirt.py
@@ -1279,9 +1279,13 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
                 mac=port.mac,
                 rom=self._spec.iface_rom_file,
                 mtu=self._spec.iface_mtu,
-                # TODO(akremenetsky): This parameter should be taken from
-                # the network
-                iface_type=self._spec.network_type,
+                # The port a machine is created with is always the transient
+                # boot network (see pool.py's MetaMachine.dump_to_dp), which
+                # is always a plain libvirt virtual network - never the
+                # hypervisor's own (possibly bridge-type) main network. The
+                # real port replaces it later via attach_port(), which does
+                # use self._spec.network_type.
+                iface_type="network",
                 source=port.source,
             )
 

--- a/exordos_core/tests/unit/compute/pool/drivers/test_libvirt.py
+++ b/exordos_core/tests/unit/compute/pool/drivers/test_libvirt.py
@@ -26,19 +26,53 @@ import pytest
 # collection when they're not available.
 pytest.importorskip("libvirt")
 
+from exordos_core.compute import constants as nc  # noqa: E402
 from exordos_core.compute.dm import models  # noqa: E402
 from exordos_core.compute.pool.drivers.libvirt import LibvirtPoolDriver  # noqa: E402
 from exordos_core.compute.pool.drivers.libvirt import XMLLibvirtInstance  # noqa: E402
 from exordos_core.compute.pool.drivers.libvirt import domain_template  # noqa: E402
 
 
-def _local_driver() -> LibvirtPoolDriver:
+def _local_driver(network_type: str = "network") -> LibvirtPoolDriver:
     # libvirt's built-in "test" driver simulates a hypervisor in-memory -
     # no real virtualization or daemon needed, so real libvirt calls
-    # (lookupByUUIDString, etc.) can be exercised end-to-end.
-    spec = models.LibvirtPoolDriverSpec(connection_uri="test:///default")
-    pool = models.MachinePool(uuid=sys_uuid.uuid4(), name="test-pool", driver_spec=spec)
+    # (lookupByUUIDString, etc.) can be exercised end-to-end. It even ships
+    # a default storage pool ("default-pool"), so create_machine() can be
+    # exercised end-to-end too.
+    spec = models.LibvirtPoolDriverSpec(
+        connection_uri="test:///default",
+        network_type=network_type,
+        storage_pool="default-pool",
+    )
+    pool = models.MachinePool(
+        uuid=sys_uuid.uuid4(), name="test-pool", driver_spec=spec
+    )
     return LibvirtPoolDriver(pool)
+
+
+def _machine() -> models.Machine:
+    return models.Machine(
+        uuid=sys_uuid.uuid4(),
+        project_id=sys_uuid.uuid4(),
+        name="test-vm",
+        cores=1,
+        ram=512,
+    )
+
+
+def _port(uuid: sys_uuid.UUID, source: str) -> models.Port:
+    return models.Port(
+        uuid=uuid,
+        project_id=sys_uuid.uuid4(),
+        mac=models.Port.generate_mac(),
+        source=source,
+        status=nc.PortStatus.ACTIVE.value,
+    )
+
+
+def _live_interface(driver: LibvirtPoolDriver, machine: models.Machine) -> ET.Element:
+    domain = driver._client.lookupByUUIDString(str(machine.uuid))
+    return ET.fromstring(domain.XMLDesc()).find(".//devices/interface")
 
 
 def test_domain_console_logs_to_file():
@@ -178,3 +212,61 @@ class TestDeleteMachine:
 
         storage_pool = driver._client.storagePoolLookupByName("default-pool")
         assert list(storage_pool.listAllVolumes()) == []
+
+
+class TestCreateMachine:
+    def test_boot_port_always_uses_network_type_on_a_bridge_hypervisor(self):
+        # Regression: a bridge-type hypervisor must not have the boot
+        # network's (logical, potentially long) name treated as a literal
+        # host bridge device name - libvirt rejects that outright as too
+        # long for IFNAMSIZ.
+        driver = _local_driver(network_type="bridge")
+        machine = _machine()
+        port = _port(nc.BOOT_NETWORK_PORT_UUID, source="exordos-core-boot-net")
+
+        driver.create_machine(machine, volumes=[], ports=[port])
+
+        interface = _live_interface(driver, machine)
+        assert interface.get("type") == "network"
+        assert interface.find("source").get("network") == "exordos-core-boot-net"
+
+    def test_real_port_honors_the_hypervisors_network_type(self):
+        # Regression: on a real bridge-type hypervisor, ports are raw
+        # bridge-type interfaces (source=<bridge device>) - not a libvirt
+        # network wrapping one. create_machine() is also used by
+        # recreate_machine() to rebuild the domain with the real port(s)
+        # post-flash, so it must not force type='network' on those.
+        driver = _local_driver(network_type="bridge")
+        machine = _machine()
+        port = _port(sys_uuid.uuid4(), source="br0")
+
+        driver.create_machine(machine, volumes=[], ports=[port])
+
+        interface = _live_interface(driver, machine)
+        assert interface.get("type") == "bridge"
+        assert interface.find("source").get("bridge") == "br0"
+
+
+class TestAttachPort:
+    def test_honors_the_hypervisors_network_type_for_bridge_hypervisors(self):
+        # Regression: attach_port() is only ever used for the real port,
+        # which on a bridge-type hypervisor is a raw bridge-type interface
+        # (source=<bridge device>) - not a libvirt network wrapping one.
+        #
+        # libvirt's test:// driver doesn't support attachDeviceFlags()'s
+        # LIVE+CONFIG flag combination, so mock the domain lookup instead
+        # of exercising a real domain end-to-end.
+        driver = _local_driver(network_type="bridge")
+        machine = _machine()
+        port = _port(sys_uuid.uuid4(), source="br0")
+
+        mock_domain = mock.MagicMock()
+        with mock.patch.object(
+            driver._client, "lookupByUUIDString", return_value=mock_domain
+        ):
+            driver.attach_port(machine, port)
+
+        interface_xml, _flags = mock_domain.attachDeviceFlags.call_args[0]
+        interface = ET.fromstring(interface_xml)
+        assert interface.get("type") == "bridge"
+        assert interface.find("source").get("bridge") == "br0"

--- a/exordos_core/tests/unit/compute/pool/drivers/test_libvirt.py
+++ b/exordos_core/tests/unit/compute/pool/drivers/test_libvirt.py
@@ -247,6 +247,37 @@ class TestCreateMachine:
         assert interface.find("source").get("bridge") == "br0"
 
 
+class TestListInterfaces:
+    def test_update_preserves_each_ports_original_interface_type(self):
+        # Regression: _list_interfaces() used to reconstruct every live
+        # interface with the same all-zero sentinel UUID reserved for the
+        # transient boot port (BOOT_NETWORK_PORT_UUID). set_machine_cores(),
+        # set_machine_ram(), rename_machine() and recreate_machine(ports=
+        # None) all feed its result straight back into create_machine(), so
+        # on a bridge-type hypervisor a real bridge port would round-trip
+        # back as type='network' too.
+        driver = _local_driver(network_type="bridge")
+        machine = _machine()
+        boot_port = _port(nc.BOOT_NETWORK_PORT_UUID, source="exordos-core-boot-net")
+        real_port = _port(sys_uuid.uuid4(), source="br0")
+
+        driver.create_machine(machine, volumes=[], ports=[boot_port, real_port])
+
+        driver.set_machine_cores(machine, cores=2)
+
+        domain = driver._client.lookupByUUIDString(str(machine.uuid))
+        interfaces = ET.fromstring(domain.XMLDesc()).findall(".//devices/interface")
+        by_mac = {i.find("mac").get("address"): i for i in interfaces}
+
+        boot_iface = by_mac[boot_port.mac]
+        assert boot_iface.get("type") == "network"
+        assert boot_iface.find("source").get("network") == "exordos-core-boot-net"
+
+        real_iface = by_mac[real_port.mac]
+        assert real_iface.get("type") == "bridge"
+        assert real_iface.find("source").get("bridge") == "br0"
+
+
 class TestAttachPort:
     def test_honors_the_hypervisors_network_type_for_bridge_hypervisors(self):
         # Regression: attach_port() is only ever used for the real port,


### PR DESCRIPTION
- The transient boot-network port (Port.from_boot_network(), identified via nc.BOOT_NETWORK_PORT_UUID) always uses iface_type="network", regardless of the hypervisor's configured network_type. This avoids libvirt treating the boot network's (potentially long) logical name as a literal host bridge device name, which previously failed with Network interface name '...' is too long on bridge-type hypervisors.
- Every other port — the real port attached via attach_port(), and the real port(s) create_machine() receives when recreate_machine() rebuilds the domain post-flash — honors the hypervisor's network_type (bridge or network) as before.
- _domain2machine()/_list_interfaces() read each interface's source by its own actual type attribute rather than assuming the hypervisor's network_type applies uniformly, since the boot port and the real port can now differ in type.