### PR TITLE
fix(build): resolve gcl_sdk migrations path instead of hardcoding it

### DIFF
--- a/exordos/images/bootstrap.sh
+++ b/exordos/images/bootstrap.sh
@@ -154,7 +154,8 @@ log "Apply migrations"
 source "$VENV_PATH/bin/activate"
 # TODO(akremenetsky): Database configuration parameters should be taken
 # from persistent configuration file.
-ra-apply-migration --config-dir "$GC_CFG_DIR/" --path "$GC_PATH/.venv/lib/python3.14/site-packages/gcl_sdk/migrations"
+GCL_SDK_MIGRATIONS_PATH=$(python3 -c "import os, gcl_sdk.migrations as m; print(os.path.dirname(m.__file__))")
+ra-apply-migration --config-dir "$GC_CFG_DIR/" --path "$GCL_SDK_MIGRATIONS_PATH"
 ra-apply-migration --config-dir "$GC_CFG_DIR/" --path "$GC_PATH/migrations"
 
 # --- Meta file migrations ---

--- a/exordos/images/install.sh
+++ b/exordos/images/install.sh
@@ -231,7 +231,8 @@ sudo cp "$GC_PATH/etc/exordos_universal_agent/logging.yaml" /etc/exordos_univers
 # 1) The bootstrap script will transfer the data to the data disk
 # 2) It's speed up the first run since the migrations are already applied.
 # 3) It's allows to debug the migrations at build time.
-OS_DB__CONNECTION_URL="postgresql://$GC_PG_USER:$GC_PG_PASS@127.0.0.1:5432/$GC_PG_DB" ra-apply-migration --path "$GC_PATH/.venv/lib/python3.14/site-packages/gcl_sdk/migrations"
+GCL_SDK_MIGRATIONS_PATH=$(python3 -c "import os, gcl_sdk.migrations as m; print(os.path.dirname(m.__file__))")
+OS_DB__CONNECTION_URL="postgresql://$GC_PG_USER:$GC_PG_PASS@127.0.0.1:5432/$GC_PG_DB" ra-apply-migration --path "$GCL_SDK_MIGRATIONS_PATH"
 OS_DB__CONNECTION_URL="postgresql://$GC_PG_USER:$GC_PG_PASS@127.0.0.1:5432/$GC_PG_DB" ra-apply-migration --path "$GC_PATH/migrations"
 
 deactivate


### PR DESCRIPTION
Fix `ra-apply-migration` failing with `FileNotFoundError` when applying `gcl_sdk`'s migrations during the core image build.

`install.sh`/`bootstrap.sh` hardcoded the migrations path as `$GC_PATH/.venv/lib/python3.14/site-packages/gcl_sdk/migrations`. This breaks in dev-mode builds (`LOCAL_GENESIS_SDK_PATH` set), where
`gcl_sdk` is installed editable via `pip install -e` and no physical `site-packages/gcl_sdk/` directory exists — only a finder redirect to the source tree.

Resolve the path dynamically instead: 

```bash
GCL_SDK_MIGRATIONS_PATH=$(python3 -c "import os, gcl_sdk.migrations as m; print(os.path.dirname(m.__file__))")
ra-apply-migration --path "$GCL_SDK_MIGRATIONS_PATH"
```

Works for both a normal and an editable install, and isn't tied to a specific python version.

## Summary by Sourcery

Resolve gcl_sdk migration path dynamically during image bootstrap and install to avoid failures in different installation modes.

Bug Fixes:
- Fix core image build migrations failing with FileNotFoundError when gcl_sdk is installed in editable mode.

Build:
- Make migration application scripts robust to Python version and installation layout by computing gcl_sdk migrations path at runtime.