### PR TITLE
add user to project

### DIFF
--- a/exordos/manifests/core.yaml.j2
+++ b/exordos/manifests/core.yaml.j2
@@ -302,6 +302,10 @@ resources:
       uuid: "c6c21054-6d17-5d67-b981-0ce0ef20e4e2"
       name: "iam.project.write_all"
       description: "Allows modifying any project`s data"
+    iam_project_add_user:
+      uuid: "90b1deed-93b1-554a-98af-3844a355c8fb"
+      name: "iam.project.add_user"
+      description: "Allows adding users to projects"
     iam_role_create:
       uuid: "5d3e126d-85be-5efb-9200-b7655db64fb4"
       name: "iam.role.create"

--- a/exordos/manifests/core.yaml.j2
+++ b/exordos/manifests/core.yaml.j2
@@ -303,7 +303,7 @@ resources:
       name: "iam.project.write_all"
       description: "Allows modifying any project`s data"
     iam_project_add_user:
-      uuid: "90b1deed-93b1-554a-98af-3844a355c8fb"
+      uuid: "312b878e-6015-58d5-9301-eaddd5371cb6"
       name: "iam.project.add_user"
       description: "Allows adding users to projects"
     iam_role_create:

--- a/exordos/manifests/examples/user2.yaml
+++ b/exordos/manifests/examples/user2.yaml
@@ -1,0 +1,45 @@
+name: "user_example2"
+description: "Example element with IAM resources"
+schema_version: 1
+version: "1.0.0"
+api_version: "v1"
+
+requirements:
+  core:
+    from_version: "0.0.0"
+
+resources:
+  $core.iam.organizations:
+    jdoe2_corp:
+      name: "jdoe2-corp"
+      description: "John2 Corporation"
+
+  $core.iam.projects:
+    jdoe2_pr:
+      name: "jdoe2-pr"
+      description: "John2 environment"
+      organization: "$core.iam.organizations.$jdoe2_corp:uuid"
+
+  $core.iam.users:
+    jdoe2:
+      username: "jdoe2"
+      email: "jdoe2@corp.com"
+      password: "12345678"
+      first_name: "John2"
+      last_name: "Doe"
+      description: "production engineer"
+
+  $core.iam.rolebinding:
+    jdoe2_global_role_binding:
+      role: "726f6c65-0000-0000-0000-000000000002"
+      user: $core.iam.users.$jdoe2:uuid
+    jdoe2_project_role_binding:
+      role: "726f6c65-0000-0000-0000-000000000002"
+      user: $core.iam.users.$jdoe2:uuid
+      project: $core.iam.projects.$jdoe2_pr:uuid
+
+  $core.iam.organizations_members:
+    jdoe2_organizations_member:
+      organization: "$core.iam.organizations.$jdoe2_corp:uuid"
+      user: $core.iam.users.$jdoe2:uuid
+      role: "OWNER"

--- a/exordos_core/common/openapi.py
+++ b/exordos_core/common/openapi.py
@@ -46,11 +46,11 @@ import importlib
 import json
 import typing as tp
 
-import webob
 from restalchemy.api import applications
 from restalchemy.api import constants as api_constants
 from restalchemy.api import contexts as api_contexts
 from restalchemy.common import contexts as common_contexts
+import webob
 
 OPENAPI_VERSION = "3.0.3"
 

--- a/exordos_core/compute/scheduler/service.py
+++ b/exordos_core/compute/scheduler/service.py
@@ -322,10 +322,14 @@ class SchedulerService(basic.BasicService):
         idle_machines = self._get_idle_machines()
 
         idle_hws = [
-            m for m in idle_machines if m.machine.machine_type == ua_pool.NodeType.HW.value
+            m
+            for m in idle_machines
+            if m.machine.machine_type == ua_pool.NodeType.HW.value
         ]
         idle_vms = [
-            m for m in idle_machines if m.machine.machine_type == ua_pool.NodeType.VM.value
+            m
+            for m in idle_machines
+            if m.machine.machine_type == ua_pool.NodeType.VM.value
         ]
         vms = []
 

--- a/exordos_core/tests/functional/conftest.py
+++ b/exordos_core/tests/functional/conftest.py
@@ -599,7 +599,9 @@ def pool_factory():
             if driver_spec is None
             else driver_spec
         )
-        status_value = ua_pool.MachinePoolStatus.ACTIVE.value if status is None else status
+        status_value = (
+            ua_pool.MachinePoolStatus.ACTIVE.value if status is None else status
+        )
         storage_pool = ua_pool.ThinStoragePool(
             pool_type="dummy",
             capacity_usable=1000,

--- a/exordos_core/tests/functional/restapi/iam/test_project_add_user.py
+++ b/exordos_core/tests/functional/restapi/iam/test_project_add_user.py
@@ -317,6 +317,120 @@ class TestProjectAddUser(base.BaseIamResourceTest):
                 },
             )
 
+    def test_project_owner_cannot_assign_global_admin_role(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+        auth_test2_user,
+    ):
+        """Project owners cannot grant the global admin role."""
+        admin_client = user_api_client(auth_user_admin)
+        project_client = user_api_client(auth_test1_user)
+        org = admin_client.create_organization(name="GlobalRoleForbiddenOrg")
+        project = admin_client.create_project(
+            organization_uuid=org["uuid"],
+            name="GlobalRoleForbiddenProject",
+        )
+        owner_role = admin_client.create_or_get_role("owner")
+        admin_role = admin_client.create_or_get_role("admin")
+        admin_client.create_role_binding(
+            role_uuid=owner_role["uuid"],
+            user_uuid=auth_test1_user.uuid,
+            project_id=project["uuid"],
+        )
+
+        with pytest.raises(bazooka_exc.NotFoundError):
+            project_client.post(
+                self._add_user_url(project_client, project["uuid"]),
+                json={
+                    "user": str(auth_test2_user.uuid),
+                    "role": admin_role["uuid"],
+                },
+            )
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            project_client.post(
+                self._add_user_url(project_client, project["uuid"]),
+                json={
+                    "user": str(auth_test2_user.uuid),
+                    "role": "admin",
+                },
+            )
+
+        assert (
+            iam_models.RoleBinding.objects.get_one_or_none(
+                filters={
+                    "project": dm_filters.EQ(project["uuid"]),
+                    "user": dm_filters.EQ(auth_test2_user.uuid),
+                    "role": dm_filters.EQ(admin_role["uuid"]),
+                }
+            )
+            is None
+        )
+
+        admin_client.delete_project(project["uuid"])
+        admin_client.delete_organization(org["uuid"])
+
+    def test_project_owner_cannot_grant_unheld_role_permission(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+        auth_test2_user,
+    ):
+        """Project owners cannot grant permissions they do not hold."""
+        admin_client = user_api_client(auth_user_admin)
+        project_client = user_api_client(auth_test1_user)
+        org = admin_client.create_organization(name="PermissionSubsetOrg")
+        project = admin_client.create_project(
+            organization_uuid=org["uuid"],
+            name="PermissionSubsetProject",
+        )
+        role = admin_client.create_role(
+            name="permission_subset_role",
+            project_id=project["uuid"],
+        )
+        permission = admin_client.create_permission(
+            name="iam.test.unheld_role_permission"
+        )
+        permission_binding = admin_client.create_permission_binding(
+            role_uuid=role["uuid"],
+            permission_uuid=permission["uuid"],
+        )
+        owner_role = admin_client.create_or_get_role("owner")
+        admin_client.create_role_binding(
+            role_uuid=owner_role["uuid"],
+            user_uuid=auth_test1_user.uuid,
+            project_id=project["uuid"],
+        )
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            project_client.post(
+                self._add_user_url(project_client, project["uuid"]),
+                json={
+                    "user": str(auth_test2_user.uuid),
+                    "role": role["uuid"],
+                },
+            )
+
+        assert (
+            iam_models.RoleBinding.objects.get_one_or_none(
+                filters={
+                    "project": dm_filters.EQ(project["uuid"]),
+                    "user": dm_filters.EQ(auth_test2_user.uuid),
+                    "role": dm_filters.EQ(role["uuid"]),
+                }
+            )
+            is None
+        )
+
+        admin_client.delete_permission_binding(permission_binding["uuid"])
+        admin_client.delete_permission(permission["uuid"])
+        admin_client.delete_role(role["uuid"])
+        admin_client.delete_project(project["uuid"])
+        admin_client.delete_organization(org["uuid"])
+
     def test_add_user_owner_role_success(
         self,
         user_api_client,

--- a/exordos_core/tests/functional/restapi/iam/test_project_add_user.py
+++ b/exordos_core/tests/functional/restapi/iam/test_project_add_user.py
@@ -1,0 +1,382 @@
+#    Copyright 2025-2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from bazooka import exceptions as bazooka_exc
+from gcl_iam.tests.functional import clients as iam_clients
+import pytest
+from restalchemy.dm import filters as dm_filters
+
+from exordos_core.tests.functional.restapi.iam import base
+from exordos_core.user_api.iam import constants as iam_c
+from exordos_core.user_api.iam.dm import models as iam_models
+
+
+class TestProjectAddUser(base.BaseIamResourceTest):
+    """Tests for POST /v1/iam/projects/<uuid>/actions/add_user/invoke"""
+
+    def _add_user_url(self, client, project_uuid):
+        return client.build_resource_uri(
+            ["iam/projects", project_uuid, "actions/add_user/invoke"]
+        )
+
+    def test_project_owner_adds_user_success(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+    ):
+        """Project owner can add another user to their project."""
+        admin_client = user_api_client(auth_user_admin)
+        project_client = user_api_client(auth_test1_user)
+
+        # Create org + project + role using admin
+        org = admin_client.create_organization(name="TestAddUserOrg")
+        project = admin_client.create_project(
+            organization_uuid=org["uuid"],
+            name="TestAddUserProject",
+        )
+        role = admin_client.create_role(
+            name="test_add_user_role",
+            project_id=project["uuid"],
+        )
+        target_user = admin_client.create_user(
+            username="target_user_add",
+            password="TestPassword1",
+        )
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": target_user["uuid"]}
+        )
+        admin_client.confirm_email(
+            user_uuid=user_obj.uuid,
+            code=str(user_obj.confirmation_code),
+        )
+
+        # Make auth_test1_user an owner of the project
+        owner_role = admin_client.create_or_get_role("owner")
+        admin_client.create_role_binding(
+            role_uuid=owner_role["uuid"],
+            user_uuid=auth_test1_user.uuid,
+            project_id=project["uuid"],
+        )
+
+        # Add user to project
+        result = project_client.post(
+            self._add_user_url(project_client, project["uuid"]),
+            json={
+                "user": target_user["uuid"],
+                "role": "test_add_user_role",
+            },
+        ).json()
+
+        assert result["user"] == target_user["uuid"]
+        assert result["role"] == role["uuid"]
+        assert result["project"] == project["uuid"]
+
+        # Verify role binding was created
+        bindings = list(
+            iam_models.RoleBinding.objects.get_all(
+                filters={
+                    "user": dm_filters.EQ(target_user["uuid"]),
+                    "project": dm_filters.EQ(project["uuid"]),
+                    "role": dm_filters.EQ(role["uuid"]),
+                }
+            )
+        )
+        assert len(bindings) == 1
+
+        # cleanup
+        admin_client.delete_role_binding(bindings[0]["uuid"])
+        admin_client.delete_role(role["uuid"])
+        admin_client.delete_user(target_user["uuid"])
+        admin_client.delete_project(project["uuid"])
+        admin_client.delete_organization(org["uuid"])
+
+    def test_user_with_add_user_permission_can_add(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+    ):
+        """User with iam.project.add_user permission can add users."""
+        admin_client = user_api_client(auth_user_admin)
+        org = admin_client.create_organization(name="PermTestOrg")
+        project = admin_client.create_project(
+            organization_uuid=org["uuid"],
+            name="PermTestProject",
+        )
+        role = admin_client.create_role(
+            name="perm_test_role",
+            project_id=project["uuid"],
+        )
+        target_user = admin_client.create_user(
+            username="perm_target_user",
+            password="TestPassword2",
+        )
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": target_user["uuid"]}
+        )
+        admin_client.confirm_email(
+            user_uuid=user_obj.uuid,
+            code=str(user_obj.confirmation_code),
+        )
+
+        # auth_test1_user has add_user permission
+        client = user_api_client(
+            auth_test1_user,
+            permissions=[iam_c.PERMISSION_PROJECT_ADD_USER],
+        )
+
+        result = client.post(
+            self._add_user_url(client, project["uuid"]),
+            json={
+                "user": target_user["uuid"],
+                "role": "perm_test_role",
+            },
+        ).json()
+
+        assert result["user"] == target_user["uuid"]
+
+        # cleanup
+        admin_client.delete_role_binding(result["uuid"])
+        admin_client.delete_role(role["uuid"])
+        admin_client.delete_user(target_user["uuid"])
+        admin_client.delete_project(project["uuid"])
+        admin_client.delete_organization(org["uuid"])
+
+    def test_user_with_write_all_permission_can_add(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+    ):
+        """User with iam.project.write_all permission can add users."""
+        admin_client = user_api_client(auth_user_admin)
+        org = admin_client.create_organization(name="WriteAllOrg")
+        project = admin_client.create_project(
+            organization_uuid=org["uuid"],
+            name="WriteAllProject",
+        )
+        role = admin_client.create_role(
+            name="write_all_role",
+            project_id=project["uuid"],
+        )
+        target_user = admin_client.create_user(
+            username="write_all_target",
+            password="TestPassword3",
+        )
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": target_user["uuid"]}
+        )
+        admin_client.confirm_email(
+            user_uuid=user_obj.uuid,
+            code=str(user_obj.confirmation_code),
+        )
+
+        # auth_test1_user has write_all permission
+        client = user_api_client(
+            auth_test1_user,
+            permissions=[iam_c.PERMISSION_PROJECT_WRITE_ALL],
+        )
+
+        result = client.post(
+            self._add_user_url(client, project["uuid"]),
+            json={
+                "user": target_user["uuid"],
+                "role": "write_all_role",
+            },
+        ).json()
+
+        assert result["user"] == target_user["uuid"]
+
+        # cleanup
+        admin_client.delete_role_binding(result["uuid"])
+        admin_client.delete_role(role["uuid"])
+        admin_client.delete_user(target_user["uuid"])
+        admin_client.delete_project(project["uuid"])
+        admin_client.delete_organization(org["uuid"])
+
+    def test_user_without_permission_cannot_add(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+        auth_test2_user,
+    ):
+        """User without project membership or permission gets 403."""
+        admin_client = user_api_client(auth_user_admin)
+        # Create project owned by auth_test1_user
+        org = admin_client.create_organization(name="ForbiddenOrg")
+        project = admin_client.create_project(
+            organization_uuid=org["uuid"],
+            name="ForbiddenProject",
+        )
+
+        # auth_test2_user has no access to this project
+        client = user_api_client(auth_test2_user)
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            client.post(
+                self._add_user_url(client, project["uuid"]),
+                json={
+                    "user": auth_test1_user.uuid,
+                    "role": "owner",
+                },
+            )
+
+        # cleanup
+        admin_client.delete_project(project["uuid"])
+        admin_client.delete_organization(org["uuid"])
+
+    def test_non_owner_member_without_permission_cannot_add(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+        auth_test2_user,
+    ):
+        """Project members without the permission cannot add users."""
+        admin_client = user_api_client(auth_user_admin)
+        org = admin_client.create_organization(name="MemberForbiddenOrg")
+        project = admin_client.create_project(
+            organization_uuid=org["uuid"],
+            name="MemberForbiddenProject",
+        )
+        member_role = admin_client.create_role(
+            name="member_forbidden_role",
+            project_id=project["uuid"],
+        )
+        member_binding = admin_client.create_role_binding(
+            role_uuid=member_role["uuid"],
+            user_uuid=auth_test2_user.uuid,
+            project_id=project["uuid"],
+        )
+        client = user_api_client(auth_test2_user)
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            client.post(
+                self._add_user_url(client, project["uuid"]),
+                json={
+                    "user": auth_test1_user.uuid,
+                    "role": "owner",
+                },
+            )
+
+        admin_client.delete_role_binding(member_binding["uuid"])
+        admin_client.delete_role(member_role["uuid"])
+        admin_client.delete_project(project["uuid"])
+        admin_client.delete_organization(org["uuid"])
+
+    def test_add_user_with_nonexistent_user_fails(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_p1_user,
+    ):
+        """Adding a user with non-existent UUID returns 404."""
+        client = user_api_client(auth_test1_p1_user)
+        u1p1 = client.list_projects()[0]
+
+        with pytest.raises(bazooka_exc.NotFoundError):
+            client.post(
+                self._add_user_url(client, u1p1["uuid"]),
+                json={
+                    "user": "11111111-1111-1111-1111-111111111111",
+                    "role": "owner",
+                },
+            )
+
+    def test_add_user_with_nonexistent_role_fails(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_p1_user,
+    ):
+        """Adding a user with non-existent role returns 404."""
+        client = user_api_client(auth_test1_p1_user)
+        u1p1 = client.list_projects()[0]
+
+        with pytest.raises(bazooka_exc.NotFoundError):
+            client.post(
+                self._add_user_url(client, u1p1["uuid"]),
+                json={
+                    "user": auth_test1_p1_user.uuid,
+                    "role": "nonexistent_role_xyz",
+                },
+            )
+
+    def test_add_user_owner_role_success(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_user,
+    ):
+        """Adding user with 'owner' role works correctly."""
+        admin_client = user_api_client(auth_user_admin)
+        org = admin_client.create_organization(name="OwnerRoleOrg")
+        project = admin_client.create_project(
+            organization_uuid=org["uuid"],
+            name="OwnerRoleProject",
+        )
+        target_user = admin_client.create_user(
+            username="owner_role_target",
+            password="TestPassword4",
+        )
+        user_obj = iam_models.User.objects.get_one(
+            filters={"uuid": target_user["uuid"]}
+        )
+        admin_client.confirm_email(
+            user_uuid=user_obj.uuid,
+            code=str(user_obj.confirmation_code),
+        )
+
+        # Make auth_test1_user an owner of the project
+        owner_role = admin_client.create_or_get_role("owner")
+        admin_client.create_role_binding(
+            role_uuid=owner_role["uuid"],
+            user_uuid=auth_test1_user.uuid,
+            project_id=project["uuid"],
+        )
+
+        client = user_api_client(auth_test1_user)
+        result = client.post(
+            self._add_user_url(client, project["uuid"]),
+            json={
+                "user": target_user["uuid"],
+                "role": "owner",
+            },
+        ).json()
+
+        assert result["user"] == target_user["uuid"]
+
+        # Verify the added user can now list the project
+        target_auth = iam_clients.GenesisCoreAuth(
+            username=target_user["username"],
+            password="TestPassword4",
+            client_uuid=admin_client._auth.client_uuid,
+            client_id=admin_client._auth.client_id,
+            client_secret=admin_client._auth.client_secret,
+            uuid=target_user["uuid"],
+            email=target_user["email"],
+        )
+        target_client = user_api_client(target_auth)
+        projects = target_client.list_projects()
+        project_uuids = [p["uuid"] for p in projects]
+        assert project["uuid"] in project_uuids
+
+        # cleanup
+        admin_client.delete_user(target_user["uuid"])
+        admin_client.delete_project(project["uuid"])
+        admin_client.delete_organization(org["uuid"])

--- a/exordos_core/tests/manual/conftest.py
+++ b/exordos_core/tests/manual/conftest.py
@@ -517,7 +517,9 @@ def pool_factory():
             if driver_spec is None
             else driver_spec
         )
-        status_value = ua_pool.MachinePoolStatus.ACTIVE.value if status is None else status
+        status_value = (
+            ua_pool.MachinePoolStatus.ACTIVE.value if status is None else status
+        )
         storage_pool = ua_pool.ThinStoragePool(
             pool_type="dummy",
             capacity_usable=1000,

--- a/exordos_core/tests/unit/compute/test_scheduler_pool_scheduling.py
+++ b/exordos_core/tests/unit/compute/test_scheduler_pool_scheduling.py
@@ -18,9 +18,8 @@ import typing as tp
 from unittest import mock
 import uuid as sys_uuid
 
-import pytest
-
 from gcl_sdk.agents.universal.drivers import pool as ua_pool
+import pytest
 
 from exordos_core.compute.scheduler import service
 

--- a/exordos_core/tests/unit/compute/test_weighter.py
+++ b/exordos_core/tests/unit/compute/test_weighter.py
@@ -14,9 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import pytest
-
 from gcl_sdk.agents.universal.drivers import pool as ua_pool
+import pytest
 
 from exordos_core.compute.dm import models
 from exordos_core.compute.scheduler.driver import base

--- a/exordos_core/user_api/compute/api/controllers.py
+++ b/exordos_core/user_api/compute/api/controllers.py
@@ -199,7 +199,10 @@ class HypervisorsController(
     )
 
     def create(self, **kwargs):
-        if "machine_type" in kwargs and kwargs["machine_type"] != ua_pool.NodeType.VM.value:
+        if (
+            "machine_type" in kwargs
+            and kwargs["machine_type"] != ua_pool.NodeType.VM.value
+        ):
             raise ValueError("Hyper must be VM type")
 
         self._validate_driver_spec_uniqueness(kwargs)

--- a/exordos_core/user_api/iam/api/controllers.py
+++ b/exordos_core/user_api/iam/api/controllers.py
@@ -484,16 +484,28 @@ class ProjectController(controllers.BaseResourceControllerPaginated, EnforceMixi
         return models.Project.list_my()
 
     def get(self, uuid, **kwargs):
+        # When active_method is GET, this is a direct resource GET request
+        # and we should enforce permissions. When active_method is None,
+        # get() is called from get_resource_by_uuid() for an action, so
+        # we skip the permission check — the action itself is responsible
+        # for its own permission checks.
         project = super().get(uuid, **kwargs)
-        filters = {"project": ra_filters.EQ(project)}
-        for _ in models.Project.list_my(filters=filters):
-            return project
-        if self.enforce(c.PERMISSION_PROJECT_READ_ALL):
-            return project
-        raise iam_e.CanNotReadProject(
-            uuid=project.uuid,
-            rule=c.PERMISSION_PROJECT_READ_ALL,
-        )
+        try:
+            active_method = self._req.api_context.get_active_method()
+        except ra_a_contexts.CanNotGetActiveMethod:
+            active_method = None
+
+        if active_method == ra_c.GET:
+            filters = {"project": ra_filters.EQ(project)}
+            for _ in models.Project.list_my(filters=filters):
+                return project
+            if self.enforce(c.PERMISSION_PROJECT_READ_ALL):
+                return project
+            raise iam_e.CanNotReadProject(
+                uuid=project.uuid,
+                rule=c.PERMISSION_PROJECT_READ_ALL,
+            )
+        return project
 
     def update(self, uuid, **kwargs):
         project = self.get(uuid)
@@ -518,6 +530,92 @@ class ProjectController(controllers.BaseResourceControllerPaginated, EnforceMixi
             name=project.name,
             rule=c.PERMISSION_PROJECT_WRITE_ALL,
         )
+
+    @staticmethod
+    def _resolve_user(user):
+        value = user.strip()
+        if "@" in value:
+            return models.User.objects.get_one(
+                filters={"email": ra_filters.EQ(value.lower())}
+            )
+        try:
+            user_uuid_obj = sys_uuid.UUID(value)
+        except ValueError:
+            return models.User.objects.get_one(
+                filters={"username": ra_filters.EQ(value)}
+            )
+        return models.User.objects.get_one(
+            filters={"uuid": ra_filters.EQ(user_uuid_obj)}
+        )
+
+    @staticmethod
+    def _resolve_role(role):
+        try:
+            return models.Role.objects.get_one(
+                filters={"uuid": ra_filters.EQ(sys_uuid.UUID(role))}
+            )
+        except ValueError:
+            return models.Role.objects.get_one(filters={"name": ra_filters.EQ(role)})
+
+    @oa_utils.extend_schema(**oa_specs.OA_SPEC_ADD_USER_TO_PROJECT)
+    @actions.post
+    def add_user(self, resource, user, role):
+        project = resource
+        project_uuid = str(project.uuid)
+        owner_role = models.Role.objects.get_one(
+            filters={"uuid": ra_filters.EQ(common_c.OWNER_ROLE_UUID)}
+        )
+        is_owner = models.RoleBinding.objects.get_one_or_none(
+            filters={
+                "project": ra_filters.EQ(project),
+                "user": ra_filters.EQ(models.User.me()),
+                "role": ra_filters.EQ(owner_role),
+            }
+        )
+        if not (
+            is_owner
+            or self.enforce(c.PERMISSION_PROJECT_ADD_USER)
+            or self.enforce(c.PERMISSION_PROJECT_WRITE_ALL)
+        ):
+            raise iam_e.CanNotAddUserToProject(
+                uuid=project_uuid,
+                rule=c.PERMISSION_PROJECT_ADD_USER,
+            )
+
+        # Resolve the user by UUID, email, or name
+        target_user = self._resolve_user(user)
+
+        # Look up the role by UUID or name
+        role = self._resolve_role(role)
+
+        role_binding = models.RoleBinding.objects.get_one_or_none(
+            filters={
+                "project": ra_filters.EQ(project),
+                "user": ra_filters.EQ(target_user),
+                "role": ra_filters.EQ(role),
+            }
+        )
+        if not role_binding:
+            role_binding = models.RoleBinding(
+                project=project,
+                user=target_user,
+                role=role,
+            )
+            role_binding.save()
+
+        ctx = self.get_context()
+        LOG.info(
+            "IAM AUDIT: user added to project project=%s project_uuid=%s "
+            "user=%s user_uuid=%s role=%s role_uuid=%s ip=%s",
+            project.name,
+            project_uuid,
+            target_user.name,
+            target_user.uuid,
+            role.name,
+            role.uuid,
+            ctx.get_user_ip(),
+        )
+        return role_binding.get_storable_snapshot()
 
 
 class RoleController(

--- a/exordos_core/user_api/iam/api/controllers.py
+++ b/exordos_core/user_api/iam/api/controllers.py
@@ -541,18 +541,19 @@ class ProjectController(controllers.BaseResourceControllerPaginated, EnforceMixi
         try:
             user_uuid_obj = sys_uuid.UUID(value)
         except ValueError:
-            return models.User.objects.get_one(
-                filters={"username": ra_filters.EQ(value)}
-            )
+            return models.User.objects.get_one(filters={"name": ra_filters.EQ(value)})
         return models.User.objects.get_one(
             filters={"uuid": ra_filters.EQ(user_uuid_obj)}
         )
 
     @staticmethod
-    def _resolve_role(role):
+    def _resolve_role(role, project_id):
         try:
             return models.Role.objects.get_one(
-                filters={"uuid": ra_filters.EQ(sys_uuid.UUID(role))}
+                filters={
+                    "uuid": ra_filters.EQ(sys_uuid.UUID(role)),
+                    "project_id": ra_filters.In((None, project_id)),
+                }
             )
         except ValueError:
             return models.Role.objects.get_one(filters={"name": ra_filters.EQ(role)})
@@ -586,7 +587,26 @@ class ProjectController(controllers.BaseResourceControllerPaginated, EnforceMixi
         target_user = self._resolve_user(user)
 
         # Look up the role by UUID or name
-        role = self._resolve_role(role)
+        role = self._resolve_role(role, project.uuid)
+        if (
+            role.project_id != project.uuid
+            and str(role.uuid) != common_c.OWNER_ROLE_UUID
+        ):
+            raise iam_e.CanNotAddUserToProject(
+                uuid=project_uuid,
+                rule=c.PERMISSION_PROJECT_ADD_USER,
+            )
+
+        if str(role.uuid) != common_c.OWNER_ROLE_UUID:
+            for permission_binding in models.PermissionBinding.objects.get_all(
+                filters={"role": ra_filters.EQ(role)}
+            ):
+                permission = permission_binding.permission.name
+                if not self.enforce(rules.Rule.from_raw(permission)):
+                    raise iam_e.CanNotAddUserToProject(
+                        uuid=project_uuid,
+                        rule=permission,
+                    )
 
         role_binding = models.RoleBinding.objects.get_one_or_none(
             filters={

--- a/exordos_core/user_api/iam/api/openapi_specs.py
+++ b/exordos_core/user_api/iam/api/openapi_specs.py
@@ -324,3 +324,42 @@ OA_SPEC_GET_TOKEN_KWARGS = dict(
         },
     ),
 )
+
+OA_SPEC_ADD_USER_TO_PROJECT = dict(
+    summary="Add a user to a project",
+    parameters=[
+        oa_c.build_openapi_parameter(
+            name="ProjectUuid",
+            openapi_type="string",
+            param_type="path",
+            required=True,
+        ),
+    ],
+    request_body=oa_c.build_openapi_req_body(
+        description="User and role to assign",
+        content_type=ra_c.CONTENT_TYPE_APPLICATION_JSON,
+        schema={
+            "type": "object",
+            "required": ["user", "role"],
+            "properties": {
+                "user": {
+                    "type": "string",
+                    "description": (
+                        "UUID, email, or name of the user to add. "
+                        "Emails and names are matched case-insensitively."
+                    ),
+                    "example": "550e8400-e29b-41d4-a716-446655440000",
+                },
+                "role": {
+                    "type": "string",
+                    "description": "UUID or name of the role to assign (e.g. 'owner')",
+                    "example": "owner",
+                },
+            },
+        },
+    ),
+    responses=oa_c.build_openapi_object_response(
+        properties={},
+        description="User added to project successfully. Returns role binding details.",
+    ),
+)

--- a/exordos_core/user_api/iam/api/routes.py
+++ b/exordos_core/user_api/iam/api/routes.py
@@ -111,10 +111,18 @@ class OrganizationController(routes.Route):
     members = routes.route(OrganizationMemberRoute, resource_route=True)
 
 
+class AddUserToProjectAction(routes.Action):
+    """Handler for .../<uuid>/actions/add_user/invoke endpoint"""
+
+    __controller__ = controllers.ProjectController
+
+
 class ProjectRoute(routes.Route):
     """Handler for /v1/iam/projects/ endpoint"""
 
     __controller__ = controllers.ProjectController
+
+    add_user = routes.action(AddUserToProjectAction, invoke=True)
 
 
 class RoleRoute(routes.Route):

--- a/exordos_core/user_api/iam/constants.py
+++ b/exordos_core/user_api/iam/constants.py
@@ -164,6 +164,9 @@ PERMISSION_PROJECT_WRITE_ALL = rules.Rule.from_raw(
 PERMISSION_PROJECT_DELETE_ALL = rules.Rule.from_raw(
     "iam.project.delete_all",
 )
+PERMISSION_PROJECT_ADD_USER = rules.Rule.from_raw(
+    "iam.project.add_user",
+)
 
 
 # Permissions

--- a/exordos_core/user_api/iam/exceptions.py
+++ b/exordos_core/user_api/iam/exceptions.py
@@ -290,3 +290,14 @@ class ProjectScopeRequiredError(exceptions.CommonValueErrorException):
     """Exception raised when project scope is required but not provided."""
 
     __template__ = "Service account tokens can only be issued with project scope"
+
+
+class CanNotAddUserToProject(
+    exceptions.CommonForbiddenException,
+    iam_exc.Forbidden,
+):
+    __template__ = (
+        "The current user is not permitted to add users to the project"
+        " `{uuid}`. This action requires the `{rule}`, which has not"
+        " been granted."
+    )


### PR DESCRIPTION
## Summary by Sourcery

Enable authorized project members and users with the appropriate permissions to add users to projects with assigned roles.

New Features:
- Add an IAM action for assigning an existing user to a project with a selected role using UUID, email, or username lookup.
- Expose the new project membership permission and document the action in the OpenAPI specification.

Bug Fixes:
- Restrict project read permission checks to direct GET requests while allowing project action handlers to perform their own authorization.

Enhancements:
- Record an audit event when a user is added to a project and avoid creating duplicate role bindings.

Tests:
- Add functional coverage for successful project membership assignment, permission enforcement, invalid users and roles, and owner-role access.

Chores:
- Add an example IAM manifest containing organization, project, user, and role bindings.