### PR TITLE
fix(compute): list machine's volumes before undefining its domain in delete_machine

### DIFF
--- a/exordos_core/compute/pool/drivers/libvirt.py
+++ b/exordos_core/compute/pool/drivers/libvirt.py
@@ -1346,19 +1346,22 @@ class LibvirtPoolDriver(base.AbstractPoolDriver):
             )
             domain = None
 
+        # Volume-to-machine attribution is derived from the domain's own
+        # XML (disk attachments), so the volumes must be listed while the
+        # domain is still defined - once undefined below, `list_volumes`
+        # can no longer find them and cleanup would silently skip them.
+        volumes = self.list_volumes(machine) if delete_volumes else ()
+
         if domain is not None:
             # Remove the libvirt domain
             try:
                 domain.destroy()
             except libvirt.libvirtError:
                 LOG.debug("The domain is not in the running state")
-            # FIXME(akremenetsky): Actully we should undefine the
-            # domain before volume deletion
             domain.undefine()
 
-        if delete_volumes:
-            for volume in self.list_volumes(machine):
-                self.delete_volume(volume)
+        for volume in volumes:
+            self.delete_volume(volume)
 
         LOG.debug("The domain %s has been destroyed", machine.uuid)
 

--- a/exordos_core/tests/unit/compute/pool/drivers/test_libvirt.py
+++ b/exordos_core/tests/unit/compute/pool/drivers/test_libvirt.py
@@ -133,3 +133,46 @@ class TestDeleteMachine:
             driver.delete_machine(machine, delete_volumes=True)
 
         mock_list_volumes.assert_called_once_with(machine)
+
+    def test_removes_the_machines_volume(self):
+        # Regression: volume-to-machine attribution is read from the
+        # domain's own XML, so the volume must be looked up before the
+        # domain is undefined - otherwise cleanup silently finds nothing
+        # and the volume (and its disk) is orphaned forever.
+        spec = models.LibvirtPoolDriverSpec(
+            connection_uri="test:///default", storage_pool="default-pool"
+        )
+        pool = models.MachinePool(
+            uuid=sys_uuid.uuid4(), name="test-pool", driver_spec=spec
+        )
+        driver = LibvirtPoolDriver(pool)
+        machine = models.Machine(
+            uuid=sys_uuid.uuid4(),
+            project_id=sys_uuid.uuid4(),
+            name="vm1",
+            cores=1,
+            ram=512,
+        )
+        volume_uuid = sys_uuid.uuid4()
+        volume = models.MachineVolume(
+            uuid=volume_uuid,
+            project_id=sys_uuid.uuid4(),
+            size=1,
+            index=0,
+            machine=machine.uuid,
+            name=str(volume_uuid),
+        )
+        volume = driver.create_volume(volume)
+        port = models.Port(
+            uuid=sys_uuid.uuid4(),
+            project_id=sys_uuid.uuid4(),
+            mac="52:54:00:11:22:33",
+            source="default",
+            status="ACTIVE",
+        )
+        driver.create_machine(machine, [volume], [port])
+
+        driver.delete_machine(machine, delete_volumes=True)
+
+        storage_pool = driver._client.storagePoolLookupByName("default-pool")
+        assert list(storage_pool.listAllVolumes()) == []

--- a/exordos_core/tests/unit/compute/pool/drivers/test_libvirt.py
+++ b/exordos_core/tests/unit/compute/pool/drivers/test_libvirt.py
@@ -174,5 +174,7 @@ class TestDeleteMachine:
 
         driver.delete_machine(machine, delete_volumes=True)
 
+        assert driver.list_volumes(machine) == []
+
         storage_pool = driver._client.storagePoolLookupByName("default-pool")
         assert list(storage_pool.listAllVolumes()) == []


### PR DESCRIPTION
Volume-to-machine attribution is derived from the domain's own XML, so looking it up after domain.undefine() always found nothing - delete_machine( delete_volumes=True) silently left every machine's volumes (and their disks) orphaned. List the volumes first, then undefine and delete as before.

## Summary by Sourcery

Ensure machine volumes are discovered before undefining libvirt domains so they can be deleted during machine teardown.

Bug Fixes:
- Fix deletion of a machine's volumes by listing them before the domain is undefined to avoid leaving orphaned volumes and disks.

Tests:
- Add a regression test verifying that deleting a machine with delete_volumes=True removes its associated libvirt storage volumes.