### PR TITLE
add core_https

### DIFF
--- a/exordos/exordos.yaml
+++ b/exordos/exordos.yaml
@@ -72,3 +72,4 @@ build:
             - ../exordos_docs/
     - manifest: manifests/core-node-set-example.yaml.j2
     - manifest: manifests/core-service-example.yaml.j2
+    - manifest: manifests/core_https.yaml.j2

--- a/exordos/manifests/core.yaml.j2
+++ b/exordos/manifests/core.yaml.j2
@@ -318,6 +318,10 @@ exports:
     link: "$core.network.lb.$core_lb"
   core_lb_http_vhost:
     link: "$core.network.lb.$core_lb.vhosts.$core_lb_core_http"
+  core_lb_core_backend_http:
+    link: "$core.network.lb.$core_lb.backend_pools.$core_lb_core_backend_http"
+  core_lb_iam_cache_backend_http:
+    link: "$core.network.lb.$core_lb.backend_pools.$core_lb_iam_cache_backend_http"
   var_core_ip_address:
     link: "$core.vs.variables.$core_ip_address"
   var_default_cores:
@@ -330,6 +334,10 @@ exports:
     link: "$core.vs.variables.$hs256_jwks_encryption_key"
   var_iam_default_client_id:
     link: "$core.vs.variables.$iam_default_client_id"
+  var_iam_default_client_uuid:
+    link: "$core.vs.variables.$iam_default_client_uuid"
+  var_iam_default_client_secret:
+    link: "$core.vs.variables.$iam_default_client_secret"
   profile_develop:
     link: "$core.vs.profiles.$develop"
   profile_small:

--- a/exordos/manifests/core_https.yaml.j2
+++ b/exordos/manifests/core_https.yaml.j2
@@ -1,0 +1,142 @@
+name: "core_https"
+description: "https resources for Exordos Core element"
+schema_version: 1
+version: "{{ version }}"
+api_version: "v1"
+
+imports:
+  core_lb:
+    element: "$core"
+    kind: "resource"
+    link: "$core.network.lb.$core_lb"
+  core_lb_core_backend_http:
+    element: "$core"
+    kind: "resource"
+    link: "$core.network.lb.$core_lb.backend_pools.$core_lb_core_backend_http"
+  core_lb_iam_cache_backend_http:
+    element: "$core"
+    kind: "resource"
+    link: "$core.network.lb.$core_lb.backend_pools.$core_lb_iam_cache_backend_http"
+  iam_default_client_id:
+    element: "$core"
+    kind: "resource"
+    link: "$core.vs.variables.$iam_default_client_id"
+  iam_default_client_uuid:
+    element: "$core"
+    kind: "resource"
+    link: "$core.vs.variables.$iam_default_client_uuid"
+  iam_default_client_secret:
+    element: "$core"
+    kind: "resource"
+    link: "$core.vs.variables.$iam_default_client_secret"
+
+resources:
+  $core.secret.certificates:
+    core_cert:
+      name: "wildcard-core-cert-prod"
+      project_id: "12345678-c625-4fee-81d5-f691897b8142"
+      email: "infra@exordos.com"
+      method:
+        kind: dns_core
+      domains:
+        - "*.exordos.io"
+        - "exordos.io"
+
+  $core_https.imports.$core_lb.vhosts:
+    core_lb_core_https:
+      project_id: "12345678-c625-4fee-81d5-f691897b8142"
+      parent: $core_https.imports.$core_lb:uuid
+      domains:
+        - "_"
+      protocol: https
+      port: 443
+      cert:
+        kind: raw
+        crt: $core.secret.certificates.$core_cert:cert
+        key: $core.secret.certificates.$core_cert:key
+
+  $core_https.imports.$core_lb.vhosts.$core_lb_core_https.routes:
+    core_lb_core_https_route:
+      project_id: "12345678-c625-4fee-81d5-f691897b8142"
+      parent: $core_https.imports.$core_lb.vhosts.$core_lb_core_https:uuid
+      condition:
+        kind: prefix
+        value: /api/core/
+        allowed_ips:
+          - 0.0.0.0/0
+        actions:
+          - kind: backend
+            pool: $core_https.imports.$core_lb.backend_pools.$core_https.imports.$core_lb_core_backend_http:uuid
+            protocol:
+              kind: http
+        modifiers:
+          - kind: auto_header
+            headers:
+              - 'Host'
+              - 'X-Forwarded-For'
+              - 'X-Forwarded-Port'
+              - 'X-Forwarded-Proto'
+              - 'X-Forwarded-Prefix'
+          - kind: rewrite_url
+            regex: "^/api/core/(.*)"
+            replacement: "/$1"
+    core_lb_iam_clients_https:
+      project_id: "12345678-c625-4fee-81d5-f691897b8142"
+      parent: $core_https.imports.$core_lb.vhosts.$core_lb_core_https:uuid
+      condition:
+        kind: prefix
+        value: /api/core/v1/iam/clients/
+        allowed_ips:
+          - 0.0.0.0/0
+        actions:
+          - kind: backend
+            pool: $core_https.imports.$core_lb.backend_pools.$core_https.imports.$core_lb_core_backend_http:uuid
+            protocol:
+              kind: http
+        modifiers:
+          - kind: auto_header
+            headers:
+              - 'Host'
+              - 'X-Forwarded-For'
+              - 'X-Forwarded-Port'
+              - 'X-Forwarded-Proto'
+              - 'X-Forwarded-Prefix'
+          - kind: rewrite_url
+            regex: "^/api/core/(.*)"
+            replacement: "/$1"
+    core_lb_iam_default_client_https:
+      project_id: "12345678-c625-4fee-81d5-f691897b8142"
+      parent: $core_https.imports.$core_lb.vhosts.$core_lb_core_https:uuid
+      condition:
+        kind: prefix
+        value: /api/core/v1/iam/clients/default
+        allowed_ips:
+          - 0.0.0.0/0
+        actions:
+          - kind: backend
+            pool: $core_https.imports.$core_lb.backend_pools.$core_https.imports.$core_lb_iam_cache_backend_http:uuid
+            protocol:
+              kind: http
+        modifiers:
+          - kind: auto_header
+            headers:
+              - 'Host'
+              - 'X-Forwarded-For'
+              - 'X-Forwarded-Port'
+              - 'X-Forwarded-Proto'
+              - 'X-Forwarded-Prefix'
+          - kind: set_header
+            name: X-Client-Id
+            value: $core_https.imports.$iam_default_client_id:value
+          - kind: set_header
+            name: X-Client-Secret
+            value: $core_https.imports.$iam_default_client_secret:value
+          - kind: rewrite_url
+            regex: "^/api/core/v1/iam/clients/default(.*)"
+            replacement: f"/v1/iam/clients/{$core_https.imports.$iam_default_client_uuid:value}$1"
+
+exports:
+  core_cert:
+    link: "$core.secret.certificates.$core_cert"
+  core_lb_core_https:
+    link: "$core_https.imports.$core_lb.vhosts.$core_lb_core_https"


### PR DESCRIPTION
## Summary by Sourcery

Add a dedicated core HTTPS manifest to provision HTTPS vhosts and routing for Exordos Core APIs using wildcard certificates and IAM defaults.

New Features:
- Introduce a core_https manifest defining HTTPS vhost, routes, and certificates for Core API traffic.
- Expose new load balancer backend pool and IAM client variable exports required by HTTPS routing.