### PR TITLE
Return unique projects for multi-role users

### DIFF
--- a/exordos_core/tests/functional/restapi/iam/test_projects.py
+++ b/exordos_core/tests/functional/restapi/iam/test_projects.py
@@ -58,6 +58,38 @@ class TestProjects(base.BaseIamResourceTest):
         assert len(projects) == 1
         assert projects[0]["name"] == "ProjectU1P1"
 
+    def test_list_projects_deduplicates_multiple_user_roles(
+        self,
+        user_api_client,
+        auth_user_admin,
+        auth_test1_p1_user,
+    ):
+        admin_client = user_api_client(auth_user_admin)
+        client = user_api_client(auth_test1_p1_user)
+        project = client.list_projects()[0]
+        role = admin_client.create_role(
+            name="additional-project-role",
+            description="Additional role in the same project",
+            project_id=project["uuid"],
+        )
+        role_binding = None
+        try:
+            role_binding = admin_client.bind_role_to_user(
+                role["uuid"],
+                auth_test1_p1_user.uuid,
+                project["uuid"],
+            )
+
+            projects = client.list_projects()
+
+            assert [item["uuid"] for item in projects] == [project["uuid"]]
+        finally:
+            try:
+                if role_binding is not None:
+                    admin_client.delete_role_binding(role_binding["uuid"])
+            finally:
+                admin_client.delete_role(role["uuid"])
+
     def test_list_projects_invited_user_to_project(
         self,
         user_api_client,

--- a/exordos_core/tests/unit/user_api/iam/dm/test_models.py
+++ b/exordos_core/tests/unit/user_api/iam/dm/test_models.py
@@ -1,0 +1,43 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from types import SimpleNamespace
+from unittest import mock
+
+from exordos_core.user_api.iam.dm import models
+
+
+def test_project_list_my_returns_each_project_once():
+    first_project = SimpleNamespace(uuid="project-1")
+    duplicate_project = SimpleNamespace(uuid="project-1")
+    second_project = SimpleNamespace(uuid="project-2")
+    role_bindings = [
+        SimpleNamespace(project=first_project),
+        SimpleNamespace(project=duplicate_project),
+        SimpleNamespace(project=second_project),
+    ]
+
+    with (
+        mock.patch.object(models.User, "me"),
+        mock.patch.object(
+            type(models.RoleBinding.objects),
+            "get_all",
+            return_value=role_bindings,
+        ),
+    ):
+        projects = models.Project.list_my()
+
+    assert projects == [first_project, second_project]

--- a/exordos_core/user_api/iam/dm/models.py
+++ b/exordos_core/user_api/iam/dm/models.py
@@ -806,7 +806,15 @@ class Project(
             filters=filters,
             order_by={"created_at": "asc"},
         )
-        return [binding.project for binding in role_bindings]
+        # Preserve the order of the earliest role binding for each project.
+        projects = []
+        project_uuids = set()
+        for binding in role_bindings:
+            if binding.project.uuid in project_uuids:
+                continue
+            project_uuids.add(binding.project.uuid)
+            projects.append(binding.project)
+        return projects
 
     def delete(self, session=None):
         u.remove_nested_dm(RoleBinding, "project", self, session=session)


### PR DESCRIPTION
## Summary

- return each IAM project once even when a user has multiple role bindings in it
- preserve the order of the earliest matching role binding
- cover the model behavior and REST regression scenario

## Validation

- `ruff check` on the changed files
- `ruff format --check` on the changed files
- `pytest -n 0 exordos_core/tests/unit/user_api/iam/dm/test_models.py`

The added functional test could not reach its test body locally because the existing fixture setup hits a PostgreSQL 18 / RestAlchemy bytes-decoding incompatibility. CI remains the authoritative functional run.

## Summary by Sourcery

Ensure project listings for IAM users return each project only once when users hold multiple roles in the same project.

Bug Fixes:
- Prevent duplicate projects from being returned when a user has multiple role bindings within the same project.

Tests:
- Add a unit test for Project.list_my to verify it returns unique projects in order of first occurrence.
- Add a functional REST API test to ensure list_projects responses are deduplicated for users with multiple roles in a project.