### PR TITLE
Totp

### DIFF
--- a/exordos_core/tests/functional/restapi/iam/test_otp_replay.py
+++ b/exordos_core/tests/functional/restapi/iam/test_otp_replay.py
@@ -1,0 +1,240 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import contextlib
+
+import bazooka
+from bazooka import exceptions as bazooka_exc
+from gcl_iam.tests.functional import clients as iam_clients
+import pyotp
+import pytest
+from restalchemy.common import contexts as ra_contexts
+
+from exordos_core.tests.functional.restapi.iam import base
+from exordos_core.user_api.iam import constants as iam_c
+from exordos_core.user_api.iam.dm import models as iam_models
+
+
+class TestOTPReplay(base.BaseIamResourceTest):
+    """Replay protection against a real database.
+
+    The unit tests cover the flow; these exist because the guarantee itself
+    is a WHERE clause, and only Postgres can confirm it holds.
+    """
+
+    USERNAME = "otp_replay"
+    PASSWORD = "testtest"
+
+    @contextlib.contextmanager
+    def _otp_user(self, user_api_client, auth_user_admin):
+        client = user_api_client(
+            auth_user_admin,
+            permissions=[
+                iam_c.PERMISSION_USER_CREATE,
+                iam_c.PERMISSION_USER_READ_ALL,
+                iam_c.PERMISSION_USER_DELETE_ALL,
+            ],
+        )
+        created = client.create_user(
+            username=self.USERNAME,
+            password=self.PASSWORD,
+        )
+
+        user = iam_models.User.objects.get_one(filters={"uuid": created["uuid"]})
+        user.otp_secret = pyotp.random_base32()
+        user.otp_enabled = True
+        user.save()
+
+        try:
+            yield client, user
+        finally:
+            # A test may have deleted the user itself.
+            if iam_models.User.objects.get_one_or_none(
+                filters={"uuid": created["uuid"]}
+            ):
+                client.delete_user(created["uuid"])
+
+    def test_code_is_accepted_once_and_rejected_afterwards(
+        self, user_api, user_api_client, auth_user_admin
+    ):
+        with self._otp_user(user_api_client, auth_user_admin) as (_, user):
+            code = pyotp.TOTP(user.otp_secret).now()
+
+            assert user.validate_otp(code) is True
+            assert user.validate_otp(code) is False
+
+    def test_a_concurrent_request_sees_the_burned_counter(
+        self, user_api, user_api_client, auth_user_admin
+    ):
+        with self._otp_user(user_api_client, auth_user_admin) as (_, user):
+            code = pyotp.TOTP(user.otp_secret).now()
+            assert user.validate_otp(code) is True
+
+            # A second request handles its own copy of the row, so only the
+            # database can tell it the code is already spent.
+            same_user = iam_models.User.objects.get_one(
+                filters={"uuid": user.uuid},
+            )
+            assert same_user.validate_otp(code) is False
+
+    def test_counter_is_persisted(self, user_api, user_api_client, auth_user_admin):
+        with self._otp_user(user_api_client, auth_user_admin) as (_, user):
+            assert user.validate_otp(pyotp.TOTP(user.otp_secret).now()) is True
+
+            counter = iam_models.UserOtpCounter.objects.get_one(
+                filters={"uuid": user.uuid},
+            )
+            assert counter.last_counter == user.last_otp_counter()
+
+    def test_user_without_a_counter_is_accepted(
+        self, user_api, user_api_client, auth_user_admin
+    ):
+        with self._otp_user(user_api_client, auth_user_admin) as (_, user):
+            assert user.last_otp_counter() is None
+
+            assert user.validate_otp(pyotp.TOTP(user.otp_secret).now()) is True
+
+    def test_login_does_not_touch_the_user_row(
+        self, user_api, user_api_client, auth_user_admin
+    ):
+        # The counter lives apart from iam_users precisely so that signing
+        # in does not look like a change to the account.
+        with self._otp_user(user_api_client, auth_user_admin) as (_, user):
+            before = iam_models.User.objects.get_one(filters={"uuid": user.uuid})
+
+            assert user.validate_otp(pyotp.TOTP(user.otp_secret).now()) is True
+
+            after = iam_models.User.objects.get_one(filters={"uuid": user.uuid})
+            assert after.updated_at == before.updated_at
+
+    def test_counter_goes_away_with_its_user(
+        self, user_api, user_api_client, auth_user_admin
+    ):
+        with self._otp_user(user_api_client, auth_user_admin) as (client, user):
+            assert user.validate_otp(pyotp.TOTP(user.otp_secret).now()) is True
+            client.delete_user(str(user.uuid))
+
+            assert user.last_otp_counter() is None
+
+    def test_turning_otp_off_and_on_again_keeps_the_spent_steps(
+        self, user_api, user_api_client, auth_user_admin, context_storage
+    ):
+        """Switching OTP off must not hand back the steps already spent.
+
+        A time step comes from the clock, not from the secret, so the
+        counter has to outlive both the old secret and the disable/enable
+        cycle. Were it cleared, a code intercepted before the switch-off
+        could be presented once more against the new secret.
+        """
+        with self._otp_user(user_api_client, auth_user_admin) as (_, user):
+            assert user.validate_otp(pyotp.TOTP(user.otp_secret).now()) is True
+            spent = user.last_otp_counter()
+            assert spent is not None
+
+            # disable_otp and enable_otp re-check the password, and hashing
+            # it needs the global salt the service keeps in its context.
+            ctx = ra_contexts.ContextWithStorage(context_storage=context_storage)
+            with ctx.context_manager():
+                user.disable_otp(self.PASSWORD)
+                assert user.last_otp_counter() == spent
+
+                user.enable_otp(self.PASSWORD)
+                assert user.last_otp_counter() == spent
+
+                user.activate_otp(pyotp.TOTP(user.otp_secret).now())
+
+            assert user.otp_enabled is True
+            # Activation may carry the counter forward, never back.
+            assert user.last_otp_counter() >= spent
+
+            # Asked directly rather than through a generated code: whether a
+            # fresh code still falls in the spent step depends on where the
+            # wall clock happens to sit, and that must not decide the test.
+            assert user._burn_otp_counter(spent) is False
+
+    def test_a_replayed_code_is_rejected_by_the_login_endpoint(
+        self,
+        user_api,
+        user_api_client,
+        auth_user_admin,
+        default_client_uuid,
+        default_client_id,
+        default_client_secret,
+    ):
+        """The burn has to outlive the request that made it.
+
+        Every other test here calls validate_otp directly, which gets a
+        session of its own and commits on the way out. Inside a request the
+        burn joins that request's transaction instead, so a real login is
+        the only thing that shows it is actually committed rather than
+        rolled back with the handler.
+        """
+        with self._otp_user(user_api_client, auth_user_admin) as (_, user):
+            auth = iam_clients.GenesisCoreAuth(
+                username=self.USERNAME,
+                password=self.PASSWORD,
+                client_uuid=default_client_uuid,
+                client_id=default_client_id,
+                client_secret=default_client_secret,
+            )
+            url = auth.get_token_url(f"{user_api.get_endpoint()}v1/")
+            code = pyotp.TOTP(user.otp_secret).now()
+            http = bazooka.Client()
+
+            granted = http.post(
+                url,
+                auth.get_password_auth_params(),
+                headers={iam_c.HEADER_OTP_CODE: code},
+            )
+            assert "access_token" in granted.json()
+
+            with pytest.raises(bazooka_exc.ClientError):
+                http.post(
+                    url,
+                    auth.get_password_auth_params(),
+                    headers={iam_c.HEADER_OTP_CODE: code},
+                )
+
+    def test_the_burn_survives_a_rolled_back_caller(
+        self, user_api, user_api_client, auth_user_admin
+    ):
+        """A spent code stays spent even if the caller's work is undone.
+
+        Any request can roll back on a later error, and a read-only context
+        rolls back by design. If the burn rode along inside the caller's
+        transaction it would be undone with it, handing the same code back
+        for the rest of its window.
+        """
+        with self._otp_user(user_api_client, auth_user_admin) as (_, user):
+            code = pyotp.TOTP(user.otp_secret).now()
+
+            # A session in thread storage is what a request looks like from
+            # down here, and this one ends the way a failing request does.
+            with contextlib.suppress(RuntimeError):
+                with ra_contexts.Context().session_manager():
+                    assert user.validate_otp(code) is True
+                    raise RuntimeError("the request fails after the check")
+
+            assert user.last_otp_counter() is not None
+            assert user.validate_otp(code) is False
+
+    def test_counter_is_not_exposed_over_the_api(
+        self, user_api, user_api_client, auth_user_admin
+    ):
+        with self._otp_user(user_api_client, auth_user_admin) as (client, user):
+            fetched = client.get_user(str(user.uuid))
+
+            assert "last_otp_counter" not in fetched

--- a/exordos_core/tests/unit/user_api/iam/test_otp.py
+++ b/exordos_core/tests/unit/user_api/iam/test_otp.py
@@ -1,0 +1,232 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import datetime
+from unittest import mock
+import uuid
+
+from gcl_iam import exceptions as iam_e
+import pyotp
+import pytest
+from restalchemy.common import exceptions as ra_exceptions
+
+from exordos_core.user_api.iam.dm import models
+
+
+class FakeCursor:
+    def __init__(self, rowcount):
+        self.rowcount = rowcount
+
+
+class FakeSession:
+    """Stands in for the counter row the burn statement competes over.
+
+    `stored` is None while the user has no row yet, which is where every
+    user starts.
+    """
+
+    def __init__(self, stored=None):
+        self.stored = stored
+        self.statements = []
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def execute(self, statement, values):
+        self.statements.append((statement, values))
+        _uuid, counter = values
+        if self.stored is None or self.stored < counter:
+            self.stored = counter
+            return FakeCursor(1)
+        return FakeCursor(0)
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        self.closed = True
+
+
+class FakeEngine:
+    def __init__(self, session):
+        self._session = session
+
+    def get_session(self):
+        return self._session
+
+
+def current_timecode(secret):
+    totp = pyotp.TOTP(secret)
+    return totp.timecode(datetime.datetime.now(datetime.timezone.utc))
+
+
+def make_user(secret, otp_enabled):
+    return models.User.restore(
+        uuid=uuid.uuid4(),
+        name="otpuser",
+        description="",
+        email="otpuser@example.com",
+        secret_hash="x" * 128,
+        salt="s" * 24,
+        otp_secret=secret,
+        otp_enabled=otp_enabled,
+    )
+
+
+@pytest.fixture
+def secret():
+    return pyotp.random_base32()
+
+
+@pytest.fixture
+def session():
+    return FakeSession()
+
+
+@pytest.fixture
+def engine(session):
+    with mock.patch.object(
+        models.User, "_get_engine", return_value=FakeEngine(session)
+    ):
+        yield
+
+
+@pytest.fixture
+def user(secret, engine):
+    return make_user(secret, otp_enabled=True)
+
+
+class TestValidateOtp:
+    def test_accepts_a_fresh_code(self, user, secret):
+        assert user.validate_otp(pyotp.TOTP(secret).now()) is True
+
+    def test_rejects_the_same_code_twice(self, user, secret):
+        code = pyotp.TOTP(secret).now()
+
+        assert user.validate_otp(code) is True
+        assert user.validate_otp(code) is False
+
+    def test_records_the_consumed_time_step(self, user, secret, session):
+        before = current_timecode(secret)
+
+        user.validate_otp(pyotp.TOTP(secret).now())
+
+        assert session.stored in (before, current_timecode(secret))
+
+    def test_rejects_a_code_from_an_older_window(self, user, secret):
+        stale = pyotp.TOTP(secret).at(
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=60)
+        )
+
+        assert user.validate_otp(stale) is False
+
+    def test_rejects_an_empty_code_without_touching_the_counter(self, user, session):
+        assert user.validate_otp(None) is False
+        assert user.validate_otp("") is False
+        assert session.statements == []
+
+    def test_raises_when_otp_is_not_enabled(self, user, secret):
+        user.otp_enabled = False
+
+        with pytest.raises(iam_e.OTPNotEnabledError):
+            user.validate_otp(pyotp.TOTP(secret).now())
+
+    def test_loses_the_race_when_another_request_burned_first(
+        self, user, secret, session
+    ):
+        code = pyotp.TOTP(secret).now()
+        # A concurrent request carrying the same code got there first.
+        session.stored = current_timecode(secret)
+
+        assert user.validate_otp(code) is False
+
+    def test_burn_is_a_single_guarded_statement(self, user, secret, session):
+        # The whole guarantee lives in this WHERE clause: without it two
+        # concurrent requests both read the old counter and both pass.
+        user.validate_otp(pyotp.TOTP(secret).now())
+
+        statement, values = session.statements[0]
+        assert "ON CONFLICT (uuid) DO UPDATE" in statement
+        assert "last_counter < EXCLUDED.last_counter" in statement
+        assert values == (user.uuid, session.stored)
+
+    def test_writes_only_to_the_counter_table(self, user, secret, session):
+        # A login must not touch the user row, or it would keep bumping
+        # iam_users.updated_at.
+        user.validate_otp(pyotp.TOTP(secret).now())
+
+        statement, _values = session.statements[0]
+        assert "iam_user_otp_counters" in statement
+        assert "iam_users" not in statement
+
+    def test_burn_commits_on_its_own(self, user, secret, session):
+        # A spent code has to stay spent even if the request that spent it
+        # rolls back, so the burn must not ride on the caller's transaction.
+        user.validate_otp(pyotp.TOTP(secret).now())
+
+        assert session.committed is True
+        assert session.closed is True
+
+    def test_a_failing_burn_rolls_back_and_closes(self, user, secret, session):
+        def boom(statement, values):
+            raise RuntimeError("database is on fire")
+
+        session.execute = boom
+
+        with pytest.raises(RuntimeError):
+            user.validate_otp(pyotp.TOTP(secret).now())
+
+        assert session.rolled_back is True
+        assert session.closed is True
+
+
+class TestActivateOtp:
+    def test_burns_the_activation_code(self, secret, engine, session):
+        user = make_user(secret, otp_enabled=False)
+        before = current_timecode(secret)
+
+        with mock.patch.object(models.User, "save"):
+            user.activate_otp(pyotp.TOTP(secret).now())
+
+        assert user.otp_enabled is True
+        assert session.stored in (before, current_timecode(secret))
+
+    def test_rejects_a_wrong_code(self, secret, engine, session):
+        user = make_user(secret, otp_enabled=False)
+
+        with mock.patch.object(models.User, "save"):
+            with pytest.raises(iam_e.OTPInvalidCodeError):
+                user.activate_otp("000000")
+
+        assert session.stored is None
+
+
+class TestUserOtpCounter:
+    def test_refuses_to_be_built_without_a_user_uuid(self):
+        # The uuid is a user's; a generated one would name nobody.
+        with pytest.raises(ra_exceptions.PropertyRequired):
+            models.UserOtpCounter(last_counter=1)
+
+    def test_keeps_the_uuid_it_is_given(self):
+        user_uuid = uuid.uuid4()
+
+        counter = models.UserOtpCounter(uuid=user_uuid, last_counter=1)
+
+        assert counter.uuid == user_uuid

--- a/exordos_core/user_api/iam/dm/models.py
+++ b/exordos_core/user_api/iam/dm/models.py
@@ -471,13 +471,73 @@ class User(
             ]
         )
 
+    def _verify_totp(self, code: tp.Union[str, int]) -> tp.Optional[int]:
+        """Verify a code, returning the time step it belongs to or None.
+
+        The current time is read once and used both to verify and to derive
+        the step: reading it twice could straddle a step boundary and burn a
+        counter the code was never checked against.
+        """
+        totp = pyotp.TOTP(self.otp_secret)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        if not totp.verify(str(code), for_time=now):
+            return None
+        return totp.timecode(now)
+
+    def last_otp_counter(self, session: tp.Any = None) -> tp.Optional[int]:
+        """The last TOTP time step this user spent, or None if none yet."""
+        counter = UserOtpCounter.objects.get_one_or_none(
+            filters={"uuid": ra_filters.EQ(self.uuid)},
+            session=session,
+        )
+        return counter.last_counter if counter is not None else None
+
+    def _burn_otp_counter(self, counter: int) -> bool:
+        """Consume a TOTP time step, refusing one already used.
+
+        This is a single conditional statement rather than a
+        read-compare-write because replay is by nature concurrent: two
+        requests carrying the same code must not both observe the old
+        counter and both pass. Whoever arrives first writes the row; the
+        loser's ON CONFLICT clause finds the step already spent, updates
+        nothing, and reports no rows touched.
+
+        It deliberately runs in a session of its own instead of the
+        caller's. A spent code has to stay spent even when the request that
+        spent it does not: sharing the request's transaction would put the
+        burn back on any later rollback, and on a read-only context -- one
+        that rolls back by design -- it would be thrown away every time,
+        leaving the code replayable for the rest of its window.
+        """
+        session = self._get_engine().get_session()
+        try:
+            cursor = session.execute(
+                f"INSERT INTO {UserOtpCounter.__tablename__} "
+                "(uuid, last_counter) VALUES (%s, %s) "
+                "ON CONFLICT (uuid) DO UPDATE "
+                "SET last_counter = EXCLUDED.last_counter "
+                f"WHERE {UserOtpCounter.__tablename__}.last_counter "
+                "< EXCLUDED.last_counter;",
+                (self.uuid, counter),
+            )
+            burned = cursor.rowcount == 1
+            session.commit()
+            return burned
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
     def validate_otp(self, code):
         if not self.otp_enabled:
             raise iam_e.OTPNotEnabledError()
         if not code:
             return False
-        totp = pyotp.TOTP(self.otp_secret)
-        return totp.verify(str(code))
+        counter = self._verify_totp(code)
+        if counter is None:
+            return False
+        return self._burn_otp_counter(counter)
 
     def enable_otp(self, password):
         if self.otp_enabled:
@@ -494,10 +554,14 @@ class User(
         if not self.otp_secret:
             raise iam_e.OTPNotEnabledError()
 
-        totp = pyotp.TOTP(self.otp_secret)
+        counter = self._verify_totp(code)
 
-        if not totp.verify(str(code)):
+        if counter is None:
             raise iam_e.OTPInvalidCodeError()
+
+        # Burn the activation code too, so it cannot be replayed as the
+        # first login.
+        self._burn_otp_counter(counter)
 
         self.otp_enabled = True
         self.save()
@@ -507,10 +571,21 @@ class User(
         self.otp_secret = ""
         self.otp_enabled = False
         self.save()
+        # The counter row stays: time steps are derived from the clock, not
+        # from the secret, so keeping it means a code minted before the
+        # switch-off cannot be replayed against a freshly enabled secret.
 
     def delete(self, session=None, **kwargs):
         u.remove_nested_dm(OrganizationMember, "user", self, session=session)
         u.remove_nested_dm(RoleBinding, "user", self, session=session)
+        # Keyed by this user's own uuid; the foreign key would take it
+        # anyway, but a user's rows should not outlive the user by accident
+        # if that key is ever relaxed.
+        u.remove_all_dm(
+            UserOtpCounter,
+            filters={"uuid": ra_filters.EQ(self.uuid)},
+            session=session,
+        )
         return super().delete(session=session, **kwargs)
 
     def send_registration_event(self, app_endpoint="http://localhost/"):
@@ -602,6 +677,33 @@ class User(
 
     def process_secret(self, secret):
         self.user_source.process_secret(user=self, secret=secret)
+
+
+class UserOtpCounter(models.ModelWithRequiredUUID, orm.SQLStorableMixin):
+    """The last TOTP time step a user has spent.
+
+    It lives in its own table rather than as a column on iam_users because
+    it changes on every single login. Writing it through the user row would
+    keep moving that row's updated_at, which is meant to say when the
+    account was last changed, not when its owner last signed in.
+
+    The uuid is the user's own: a user has exactly one counter, so reusing
+    the key both expresses that and gives the burn statement something to
+    conflict on. Having no row means no code has been spent yet, which is
+    where every user starts.
+
+    Hence ModelWithRequiredUUID rather than ModelWithUUID: the plain one
+    hands out a fresh random uuid, and here a generated uuid names nobody
+    and the foreign key would reject it. Better to refuse to build the
+    object at all than to write a row keyed to no one.
+    """
+
+    __tablename__ = "iam_user_otp_counters"
+
+    last_counter = properties.property(
+        ra_types.Integer(min_value=0),
+        required=True,
+    )
 
 
 class Role(

--- a/migrations/0001-iam-otp-counter-8b17c2.py
+++ b/migrations/0001-iam-otp-counter-8b17c2.py
@@ -1,0 +1,71 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+# Replay protection for TOTP codes.
+#
+# A TOTP code stays valid for its whole 30-second step, and until now
+# nothing recorded that a code had already been spent -- so one intercepted
+# code could be presented again, in parallel, for as long as the window
+# lasted. This table remembers the last step each user consumed; the check
+# itself is an INSERT ... ON CONFLICT against it, which is what makes two
+# concurrent presentations of the same code resolve to one winner.
+#
+# It is a table of its own rather than a column on iam_users because it is
+# written on every login, and doing that through the user row would keep
+# moving iam_users.updated_at -- which is meant to say when the account was
+# last changed, not when its owner last signed in.
+#
+# The key is the user's own uuid: one counter per user. Users start with no
+# row at all, meaning "nothing spent yet", so the next code any of them
+# presents is accepted and sets the baseline.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+    def __init__(self):
+        self._depends = ["0000-squashed-current-7f2e4a.py"]
+
+    @property
+    def migration_id(self):
+        return "8b17c2a4-6e93-4d5f-8c21-9f0a3b7e2d64"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        session.execute(
+            """\
+CREATE TABLE IF NOT EXISTS iam_user_otp_counters (
+    uuid UUID NOT NULL,
+    last_counter BIGINT NOT NULL,
+    CONSTRAINT iam_user_otp_counters_pkey PRIMARY KEY (uuid),
+    CONSTRAINT iam_user_otp_counters_uuid_fkey FOREIGN KEY (uuid)
+        REFERENCES iam_users(uuid) ON UPDATE CASCADE ON DELETE CASCADE
+);
+""",
+            None,
+        )
+
+    def downgrade(self, session):
+        session.execute(
+            "DROP TABLE IF EXISTS iam_user_otp_counters;",
+            None,
+        )
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
## Summary by Sourcery

Add replay protection for TOTP-based OTP by tracking and persisting the last time step used per user and enforcing single-use codes.

Enhancements:
- Introduce a UserOtpCounter model and helper methods on User to persist and retrieve the last consumed TOTP time step without touching the main user row.
- Ensure OTP activation burns its code and retain counters across OTP disable/enable cycles while cleaning them up when a user is deleted.

Build:
- Add a database migration creating the iam_user_otp_counters table keyed by user UUID with appropriate foreign key constraints.

Tests:
- Add unit tests for TOTP validation, counter semantics, and the UserOtpCounter model, including concurrent use and error handling scenarios.
- Add functional tests against the REST API and real database to verify replay protection, transaction behavior, and that counters are not exposed over the API.