### PR TITLE
set gcl_sdk logging level to INFO

### DIFF
--- a/etc/exordos_core/logging.yaml
+++ b/etc/exordos_core/logging.yaml
@@ -28,6 +28,7 @@ loggers:
   psycopg: {}
   bazooka:
     level: WARNING
+
 root:
   handlers: [console]
   level: INFO

--- a/etc/exordos_universal_agent/logging.yaml
+++ b/etc/exordos_universal_agent/logging.yaml
@@ -17,10 +17,6 @@ loggers:
 # by default all existing loggers are disabled upon the application
 # of this config. To re-enable a logger and it's childer just add it
 # to the loggers section with any even empty fields.
-  camel:
-    handlers: [console]
-    level: WARNING
-    propagate: False
 
   genesis_universal_agent: {}
   bjoern: {}
@@ -35,4 +31,4 @@ loggers:
 
 root:
   handlers: [console]
-  level: DEBUG
+  level: INFO


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Align gcl_sdk logging level to INFO across exordos_core and exordos_universal_agent configs for more verbose SDK logging.