### PR TITLE
fix(bootstrap): sync a local hypervisor's node key at stand bootstrap

### DIFF
--- a/exordos_core/bootstrap/defaults.py
+++ b/exordos_core/bootstrap/defaults.py
@@ -22,6 +22,7 @@ import pwd
 import typing as tp
 import uuid as sys_uuid
 
+from gcl_sdk.agents.universal.dm import models as ua_models
 from gcl_sdk.infra.dm import models as infra_models
 from restalchemy.dm import filters as dm_filters
 from restalchemy.storage import exceptions as ra_exceptions
@@ -393,6 +394,10 @@ def apply_startup_db(spec: dict[str, tp.Any]) -> None:
 
     for hypervisor in stand.get("hypervisors", []):
         hypervisor["iface_mtu"] = 1500
+        # The agent encryption key isn't part of the driver spec, it's the
+        # symmetric key already written to the local agent's disk by the
+        # CLI, so it must be popped off before the driver spec is built.
+        agent_private_key = hypervisor.pop("private_key", None)
         pool_data = {
             "name": "hypervisor",
             "machine_type": "VM",
@@ -411,6 +416,17 @@ def apply_startup_db(spec: dict[str, tp.Any]) -> None:
             except ra_exceptions.ConflictRecords:
                 LOG.info("Machine pool %s already exists", pool.uuid)
             else:
+                # A local hypervisor's agent authenticates to the
+                # orch/status APIs with a node encryption key, so
+                # provision one for its node uuid, in sync with the key
+                # already written to the agent's disk by the CLI.
+                if isinstance(
+                    pool.driver_spec, compute_models.ExordosLocalHyperDriverSpec
+                ):
+                    ua_models.NodeEncryptionKey.get_or_create(
+                        pool.driver_spec.node,
+                        private_key=agent_private_key,
+                    )
                 LOG.info("Created machine pool %s", pool.uuid)
             continue
 

--- a/exordos_core/tests/functional/restapi/compute/test_hypervisor_api.py
+++ b/exordos_core/tests/functional/restapi/compute/test_hypervisor_api.py
@@ -23,6 +23,7 @@ from gcl_sdk.agents.universal.api import crypto as ua_crypto
 from gcl_sdk.agents.universal.dm import models as ua_models
 import pytest
 from restalchemy.dm import filters as dm_filters
+from restalchemy.storage import exceptions as storage_exc
 
 from exordos_core.compute import constants as nc
 
@@ -347,3 +348,36 @@ class TestHypervisorUserApi:
         assert key.private_key == private_key
 
         client.delete(client.build_resource_uri(["compute", "nodes", str(node_uuid)]))
+
+    def test_hypervisors_add_local_hyper_does_not_provision_a_node_key(
+        self,
+        pool_factory: tp.Callable,
+        user_api_client: iam_clients.GenesisCoreTestRESTClient,
+        auth_user_admin: iam_clients.GenesisCoreAuth,
+    ):
+        # A local hypervisor's universal agent gets its key by calling
+        # the `issue_key` action itself once it registers - creating the
+        # hypervisor resource must not provision one as a side effect.
+        node_uuid = sys_uuid.uuid4()
+        client = user_api_client(auth_user_admin)
+        url = client.build_collection_uri(["compute", "hypervisors"])
+
+        hypervisor = pool_factory(
+            driver_spec={
+                "kind": "exordos_local_hyper",
+                "connection_uri": "qemu:///system",
+                "node": str(node_uuid),
+            },
+        )
+        hypervisor.pop("status", None)
+        response = client.post(url, json=hypervisor)
+        assert response.status_code == 201
+
+        with pytest.raises(storage_exc.RecordNotFound):
+            ua_models.NodeEncryptionKey.objects.get_one(
+                filters={"uuid": dm_filters.EQ(node_uuid)}
+            )
+
+        client.delete(
+            client.build_resource_uri(["compute", "hypervisors", hypervisor["uuid"]])
+        )


### PR DESCRIPTION
apply_startup_db() built each stand hypervisor's driver_spec straight
from the stand config, but the CLI already generates its own
encryption key and writes it to the local agent's disk before the
control plane ever exists - nothing synced that key into
NodeEncryptionKey. Pop the config's `private_key` field (it isn't
part of the driver spec) and seed the key with it via get_or_create,
so the DB ends up in sync with what's already on disk instead of a
fresh, mismatched one.

## Summary by Sourcery

Synchronize local hypervisors’ node encryption keys with the CLI-generated agent key during bootstrap without changing MachinePool insertion behavior.

Bug Fixes:
- Ensure stand bootstrap seeds NodeEncryptionKey for local hypervisors using the existing agent private key instead of generating a mismatched key.
- Prevent hypervisor creation from implicitly provisioning a node encryption key, leaving key issuance to the universal agent workflow.

Tests:
- Add functional compute API test verifying that creating a local hypervisor does not provision a node encryption key as a side effect.
- Add unit test confirming MachinePool.insert never calls NodeEncryptionKey.get_or_create and that key provisioning is handled externally.