### PR TITLE
CI: test upgrade path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,3 +107,92 @@ jobs:
         with:
           limit-access-to-actor: true
           wait-timeout-minutes: 30
+  UpgradeE2E:
+    # Bootstraps the previous release, loads it, upgrades the core to the
+    # version this run built, and asserts the installation both survived and
+    # converged. `FuncTests` proves a fresh installation works; this job is the
+    # only thing that proves an existing one is not broken by the upgrade.
+    needs: Build
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-24.04
+    # Must exceed the sum of the scripts' own timeouts: a job killed by GitHub
+    # loses both the diagnosis and the uploaded snapshots.
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The base release is the newest release tag, so the tags have to be
+          # there.
+          fetch-depth: 0
+      - name: Setup `packer`
+        uses: hashicorp/setup-packer@main
+        with:
+          version: ${{ env.PACKER_VERSION }}
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install --yes jq postgresql-client
+      - name: Install exordos
+        run: curl -fsSL https://repo.exordos.com/install.sh | sh
+      - name: set exordos config
+        run: |
+          exordos settings set-realm default --endpoint $CORE_ENDPOINT_URL
+          exordos settings set-context default --name default --user $CORE_USERNAME --password $CORE_PASSWORD
+      - name: Install hypervisor
+        run: |
+          EXORDOS_BIN=$(which exordos)
+          sudo $EXORDOS_BIN compute hypervisors init
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build_artifacts
+          path: artifacts/
+      - name: Resolve the version pair
+        id: versions
+        run: tools/ci/upgrade/resolve-versions.sh artifacts/version.txt
+      - name: Bootstrap the previous release
+        run: |
+          exordos bootstrap -i ${{ steps.versions.outputs.prev }} -f -m core \
+            --admin-password $CORE_PASSWORD --cidr 10.20.0.0/22
+      - name: Wait for the previous release to settle
+        timeout-minutes: 20
+        run: |
+          set -eux
+          for i in {1..20}; do
+            if exordos ready_api; then break; fi
+            echo "Waiting for Exordos Core API... ($i/20)"
+            sleep 5
+          done
+          while [ "$(exordos ee l -o json -f name=core | jq -r '.[0].status')" != "ACTIVE" ]; do
+            sleep 2
+          done
+          exordos e e show core
+      - name: Seed the workload
+        run: tools/ci/upgrade/workload.sh seed
+      - name: Snapshot the installation before the upgrade
+        run: tools/ci/upgrade/snapshot.sh upgrade-e2e/before
+      - name: Check convergence before the upgrade
+        # A baseline: without it, a divergence found afterwards cannot be
+        # blamed on the upgrade.
+        run: tools/ci/upgrade/check-convergence.sh upgrade-e2e/before/divergences.json
+      - name: Upgrade the core
+        run: tools/ci/upgrade/upgrade-core.sh ${{ steps.versions.outputs.new }}
+      - name: Snapshot the installation after the upgrade
+        run: tools/ci/upgrade/snapshot.sh upgrade-e2e/after
+      - name: Check convergence after the upgrade
+        run: tools/ci/upgrade/check-convergence.sh upgrade-e2e/after/divergences.json
+      - name: Compare the snapshots
+        run: tools/ci/upgrade/compare-snapshots.sh upgrade-e2e/before upgrade-e2e/after
+      - name: Verify the workload survived
+        run: tools/ci/upgrade/workload.sh verify
+      - name: Upload the upgrade snapshots
+        uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: upgrade_e2e_snapshots
+          path: upgrade-e2e/
+          if-no-files-found: ignore
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
+        if: ${{ failure() }}
+        with:
+          limit-access-to-actor: true
+          wait-timeout-minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 50
+          # The version is derived from the nearest reachable tag, so an
+          # incomplete tag set silently mislabels the artifact — and this job
+          # runs on a self-hosted runner whose working directory outlives the
+          # run, where a shallow, tagless fetch leaves whatever tags happened
+          # to be there before. A build two commits past 0.2.10 was published
+          # as 0.2.5-dev this way. Fetch everything, like `UpgradeE2E` does:
+          # the version and the tag list have to come from the same history.
+          fetch-depth: 0
       - name: Build Exordos Core
         env:
           PUSH_CFG: ${{ secrets.PUSH_CFG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,15 @@ on:
       - 'mkdocs.yml'
       - '.markdownlint.yaml'
       - '*.md'
+  # Only on open: a branch in this repository is already covered by `push`, so
+  # reacting to every update as well would build and upgrade twice per commit.
+  pull_request:
+    types: [opened]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.markdownlint.yaml'
+      - '*.md'
 
 env:
   ARTIFACTS_PATH: artifacts
@@ -20,7 +29,13 @@ env:
 jobs:
   Build:
     runs-on: [ self-hosted, vm ]
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # A pull request from a fork carries untrusted code, and this job runs on
+    # our own machine with the push credentials. Everything downstream needs
+    # the artifacts it produces, so skipping it here skips the whole workflow.
+    if: >-
+      ${{ github.actor != 'dependabot[bot]'
+          && (github.event_name != 'pull_request'
+              || github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
       fail-fast: true
     steps:

--- a/docs/core-developer-guide/upgrade-testing.md
+++ b/docs/core-developer-guide/upgrade-testing.md
@@ -1,0 +1,93 @@
+# Upgrade testing
+
+An installation that is already running is the hard case. A fresh bootstrap
+starts from an empty database, an empty data disk and no agents in the field;
+an upgrade starts from data written by an older version of the same code, and
+has to keep serving it. The `UpgradeE2E` job in `.github/workflows/build.yml`
+is what covers that case.
+
+## What the job does
+
+It runs on every push, next to `FuncTests`, and reuses the same platform: a
+GitHub-hosted runner that turns itself into a hypervisor and boots the core as
+a real virtual machine.
+
+1. **Resolve the version pair.** `NEW` is the version this run built, taken
+   from the build artifacts. `PREV` is the newest release tag that is not
+   `NEW` — what an existing installation is expected to be running. The base
+   release image must be published, and the job fails loudly if it is not:
+   skipping would turn the whole test into a green light that checks nothing.
+2. **Bootstrap `PREV`** with the public CLI, exactly as an operator would.
+3. **Put a workload on it**: core-level objects (an organization and a
+   project), the third-party `dbaas` element with its own nodes, a postgres
+   instance it provisions, and a marker row inside that database.
+4. **Snapshot and check convergence** *before* the upgrade — a baseline,
+   without which a divergence found afterwards cannot be blamed on the upgrade.
+5. **Upgrade the core** with `exordos ee update core -v NEW`, waiting for the
+   API to disappear and come back.
+6. **Assert.** Convergence again, snapshot comparison, and the workload check.
+
+## The assertion that matters
+
+Statuses lie. A resource keeps reporting `ACTIVE` while the agent re-applies it
+in a loop forever, and that is exactly how a lost payload field hides: the
+control plane sends a field the data plane drops on the way back, the two
+hashes never meet, and every reconcile iteration decides there is still work to
+do. An installation in that state looks healthy in `ee list` and serves
+requests, while its journal fills with errors.
+
+So the job compares hashes rather than statuses. For every target resource
+there must be an actual resource with the same `(kind, res_uuid)`, and their
+`hash` values must be equal — `hash`, not `full_hash`, because `hash` covers
+the target fields and is what the agent compares when it decides whether to act.
+The two sides may legitimately differ on `full_hash`, so that is reported for
+diagnosis but never fails the job.
+
+Convergence has to hold on several consecutive polls a minute apart. A single
+clean poll can be caught in the middle of a legitimate rebuild.
+
+## What else is checked
+
+- Nothing was lost: every element installed before is still installed, and the
+  node count did not drop.
+- Nothing was duplicated: no repeated `(kind, res_uuid)` resources and no
+  repeated `(name, version)` elements. An upgrade re-runs the bootstrap against
+  an already bootstrapped database, which is how duplicates get in.
+- The data survived *and* the paths are still alive: the pre-upgrade marker row
+  is still there, a new row can be written, and a new project can be created.
+  Surviving data on its own does not prove the control plane still works.
+- Only one core version is `ACTIVE` afterwards.
+
+## Layout
+
+The workflow steps are thin; the logic is in `tools/ci/upgrade/`:
+
+| Script | Purpose |
+| --- | --- |
+| `lib.sh` | API access, waiting, element lookups, marker names |
+| `resolve-versions.sh` | Pick `PREV`/`NEW`, verify the base image is published |
+| `workload.sh` | `seed` the load, `verify` it survived |
+| `snapshot.sh` | Dump the state that must not be damaged |
+| `check-convergence.sh` | Compare target and actual hashes until stable |
+| `upgrade-core.sh` | Run the upgrade and wait for the installation to return |
+| `compare-snapshots.sh` | Detect lost and duplicated objects |
+
+Actions go through the `exordos` CLI, because that is what an operator uses.
+Assertions go through the raw user API, so they depend on the API contract
+rather than on how the CLI renders a table today.
+
+Snapshots and any divergence report are uploaded as job artifacts, so a
+failure can be diagnosed without re-running the job.
+
+## Known limitation
+
+The core replaces its own image and reboots, and there is no way back if the
+new image cannot be fetched: the update data is moved off the data disk before
+the download is attempted, so a failed download leaves a machine that boots
+into an updater with nothing to apply. The job checks its preconditions up
+front and has a timeout; the installation it uses is disposable, so a brick
+costs a red job and nothing more.
+
+Database schema is not covered here — it cannot be reached from outside the
+core node. Comparing an upgraded schema against a freshly installed one belongs
+in a cheaper, database-only job.

--- a/docs/core-developer-guide/upgrade-testing.md
+++ b/docs/core-developer-guide/upgrade-testing.md
@@ -8,9 +8,14 @@ is what covers that case.
 
 ## What the job does
 
-It runs on every push, next to `FuncTests`, and reuses the same platform: a
-GitHub-hosted runner that turns itself into a hypervisor and boots the core as
-a real virtual machine.
+It runs next to `FuncTests` — on every push, and once more when a pull request
+is opened — and reuses the same platform: a GitHub-hosted runner that turns
+itself into a hypervisor and boots the core as a real virtual machine.
+
+A pull request from a fork is deliberately not built: `Build` runs on our own
+machine with the push credentials, so it refuses untrusted code, and every job
+downstream depends on the artifacts it produces. Branches in this repository
+are covered either way, because `push` fires for them.
 
 1. **Resolve the version pair.** `NEW` is the version this run built, taken
    from the build artifacts. `PREV` is the newest release tag that is not

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
     - App Guide: app-developer-guide/app-guide.md
     - Core Guide: core-developer-guide/core-guide.md
     - Repo Proxy: core-developer-guide/repo-proxy.md
+    - Upgrade Testing: core-developer-guide/upgrade-testing.md
   - OpenAPI:
     - User API: openapi/openapi_user.md
     - Boot API: openapi/openapi_boot.md

--- a/tools/ci/upgrade/check-convergence.sh
+++ b/tools/ci/upgrade/check-convergence.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+# Assert that the control plane and the data plane agree.
+#
+# This is the check that a status listing cannot give you.  Resources keep
+# reporting ACTIVE while the agent re-applies them in a loop forever, which is
+# exactly how a lost payload field hides: the target hash and the actual hash
+# never meet, so every reconcile iteration decides there is work to do.
+# `hash` — not `full_hash` — is what the agent compares when it makes that
+# decision, so that is what is asserted here; `full_hash` is only reported, as
+# the two sides may legitimately differ on fields outside the target set.
+#
+# A target with no agent is a different failure and is reported as such: the
+# scheduler leaves `agent` unset when no agent claims the capability, and
+# blaming the data plane for that sends you looking at the wrong side.
+#
+# Usage: check-convergence.sh [report.json]
+#
+# Convergence must hold on several consecutive polls: a single clean poll can
+# be caught mid-way through a legitimate rebuild.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/ci/upgrade/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+TIMEOUT="${UPGRADE_CONVERGENCE_TIMEOUT:-900}"
+STABLE_POLLS="${UPGRADE_CONVERGENCE_STABLE_POLLS:-2}"
+STABLE_INTERVAL="${UPGRADE_CONVERGENCE_STABLE_INTERVAL:-60}"
+RETRY_INTERVAL="${UPGRADE_CONVERGENCE_RETRY_INTERVAL:-15}"
+
+report_file="${1:-}"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+# Emits one object per target resource that has not converged.
+divergences() {
+    core_get /v1/ua/target_resources/ >"${work_dir}/targets.json" || return 1
+    core_get /v1/ua/resources/ >"${work_dir}/actual.json" || return 1
+
+    jq -n \
+        --slurpfile targets "${work_dir}/targets.json" \
+        --slurpfile actual "${work_dir}/actual.json" \
+        '
+        ($actual[0] | map({key: "\(.kind)/\(.res_uuid)", value: .}) | from_entries) as $by_key
+        | $targets[0]
+        | map(
+            . as $target
+            | "\($target.kind)/\($target.res_uuid)" as $key
+            | $by_key[$key] as $actual_resource
+            | if $target.agent == null then
+                  {key: $key, reason: "never scheduled: no agent has this capability",
+                   target_status: $target.status}
+              elif $actual_resource == null then
+                  {key: $key, reason: "the data plane never reported this resource",
+                   target_status: $target.status}
+              elif $actual_resource.hash != $target.hash then
+                  {key: $key, reason: "hash mismatch: the data plane cannot reproduce the target",
+                   target_status: $target.status,
+                   target_hash: $target.hash, actual_hash: $actual_resource.hash,
+                   target_full_hash: $target.full_hash,
+                   actual_full_hash: $actual_resource.full_hash}
+              elif $target.status != "ACTIVE" then
+                  {key: $key, reason: "target resource is stuck outside ACTIVE",
+                   target_status: $target.status}
+              else empty end)
+        '
+}
+
+deadline=$((SECONDS + TIMEOUT))
+clean_polls=0
+last_report="[]"
+
+while ((SECONDS < deadline)); do
+    if ! last_report="$(divergences)"; then
+        log "cannot read the resource lists, retrying"
+        clean_polls=0
+        sleep "${RETRY_INTERVAL}"
+        continue
+    fi
+    count="$(jq -r 'length' <<<"${last_report}")"
+
+    if ((count == 0)); then
+        clean_polls=$((clean_polls + 1))
+        log "converged (${clean_polls}/${STABLE_POLLS} consecutive polls clean)"
+        if ((clean_polls >= STABLE_POLLS)); then
+            total="$(jq -r 'length' "${work_dir}/targets.json")"
+            ((total > 0)) || die "no target resources at all — the installation is not doing anything"
+            log "all ${total} target resources match the data plane"
+            [[ -z "${report_file}" ]] || printf '[]\n' >"${report_file}"
+            exit 0
+        fi
+        sleep "${STABLE_INTERVAL}"
+        continue
+    fi
+
+    if ((clean_polls > 0)); then
+        log "convergence broke after ${clean_polls} clean poll(s), restarting the count"
+    fi
+    clean_polls=0
+    log "${count} resource(s) not converged yet"
+    sleep "${RETRY_INTERVAL}"
+done
+
+jq -r '.[] | "  \(.key): \(.reason) [target=\(.target_status)]"' <<<"${last_report}" >&2
+[[ -z "${report_file}" ]] || jq -S '.' <<<"${last_report}" >"${report_file}"
+die "control plane and data plane did not converge within ${TIMEOUT}s"

--- a/tools/ci/upgrade/check-convergence.sh
+++ b/tools/ci/upgrade/check-convergence.sh
@@ -26,9 +26,20 @@
 # decision, so that is what is asserted here; `full_hash` is only reported, as
 # the two sides may legitimately differ on fields outside the target set.
 #
-# A target with no agent is a different failure and is reported as such: the
-# scheduler leaves `agent` unset when no agent claims the capability, and
-# blaming the data plane for that sends you looking at the wrong side.
+# Only target resources the scheduler has given to an agent are asserted on.
+# `/v1/ua/target_resources/` is not a list of things a data plane renders: on a
+# freshly bootstrapped installation 966 of its 1069 rows carry no agent at all,
+# and they are supposed to. Most are the repository catalogue
+# (`repo_proxy_element`, one row per element version a repository offers); the
+# rest are instance-level rows (`node`, `machine`, `vs_variable`) whose
+# derivatives are the things that go to agents. Demanding that all of them
+# converge asserts that the core is doing something it never claimed to, and
+# fails every run before an upgrade is even attempted.
+#
+# What the unscheduled rows *can* hide — a capability no agent claims, so the
+# work is never handed out — is caught by comparing the snapshots instead: a
+# kind that was scheduled before the upgrade and is not after is a regression,
+# and that is a question about two runs, not about one listing.
 #
 # Usage: check-convergence.sh [report.json]
 #
@@ -61,14 +72,12 @@ divergences() {
         '
         ($actual[0] | map({key: "\(.kind)/\(.res_uuid)", value: .}) | from_entries) as $by_key
         | $targets[0]
+        | map(select(.agent != null))
         | map(
             . as $target
             | "\($target.kind)/\($target.res_uuid)" as $key
             | $by_key[$key] as $actual_resource
-            | if $target.agent == null then
-                  {key: $key, reason: "never scheduled: no agent has this capability",
-                   target_status: $target.status}
-              elif $actual_resource == null then
+            | if $actual_resource == null then
                   {key: $key, reason: "the data plane never reported this resource",
                    target_status: $target.status}
               elif $actual_resource.hash != $target.hash then
@@ -101,9 +110,9 @@ while ((SECONDS < deadline)); do
         clean_polls=$((clean_polls + 1))
         log "converged (${clean_polls}/${STABLE_POLLS} consecutive polls clean)"
         if ((clean_polls >= STABLE_POLLS)); then
-            total="$(jq -r 'length' "${work_dir}/targets.json")"
-            ((total > 0)) || die "no target resources at all — the installation is not doing anything"
-            log "all ${total} target resources match the data plane"
+            total="$(jq -r 'map(select(.agent != null)) | length' "${work_dir}/targets.json")"
+            ((total > 0)) || die "nothing is scheduled to any agent — the installation is not doing anything"
+            log "all ${total} scheduled target resources match the data plane"
             [[ -z "${report_file}" ]] || printf '[]\n' >"${report_file}"
             exit 0
         fi

--- a/tools/ci/upgrade/compare-snapshots.sh
+++ b/tools/ci/upgrade/compare-snapshots.sh
@@ -71,6 +71,24 @@ if [[ -n "${missing_elements}" ]]; then
     fail "elements lost during the upgrade: ${missing_elements//$'\n'/, }"
 fi
 
+# A capability that stops being claimed is invisible to the convergence check —
+# unscheduled work is not divergent work, it is work that never starts. It shows
+# up here instead: the upgrade may add kinds, but a kind the scheduler handed to
+# an agent before and hands to nobody after is the data plane silently losing a
+# capability.
+unscheduled_kinds="$(
+    jq -r -n \
+        --slurpfile before "${before_dir}/target_resources.json" \
+        --slurpfile after "${after_dir}/target_resources.json" \
+        '($after[0] | map(select(.agent != null) | .kind) | unique) as $now
+         | $before[0] | map(select(.agent != null) | .kind) | unique
+         | map(select(. as $kind | $now | index($kind) | not))
+         | .[]'
+)"
+if [[ -n "${unscheduled_kinds}" ]]; then
+    fail "kinds no longer scheduled to any agent: ${unscheduled_kinds//$'\n'/, }"
+fi
+
 before_nodes="$(jq -r '.nodes' "${before_dir}/counts.json")"
 after_nodes="$(jq -r '.nodes' "${after_dir}/counts.json")"
 if ((after_nodes < before_nodes)); then

--- a/tools/ci/upgrade/compare-snapshots.sh
+++ b/tools/ci/upgrade/compare-snapshots.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+# Compare the installation before and after the upgrade.
+#
+# Usage: compare-snapshots.sh <before-dir> <after-dir>
+#
+# Two failure modes are checked here that a per-object status cannot show:
+# things silently disappearing, and things silently doubling.  Re-running the
+# bootstrap against an already bootstrapped database is how duplicates get in,
+# and an upgrade runs the bootstrap again by design.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/ci/upgrade/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+before_dir="${1:?usage: compare-snapshots.sh <before-dir> <after-dir>}"
+after_dir="${2:?usage: compare-snapshots.sh <before-dir> <after-dir>}"
+
+failures=0
+
+fail() {
+    log "FAILED: $*"
+    failures=$((failures + 1))
+}
+
+# duplicates <file> <jq key expression> <what>
+duplicates() {
+    local duplicated
+    duplicated="$(jq -r "
+        group_by($2) | map(select(length > 1)) | .[] | \"\(.[0] | $2) x\(length)\"
+    " "${after_dir}/$1")"
+    if [[ -n "${duplicated}" ]]; then
+        fail "duplicated $3 after the upgrade:"$'\n'"${duplicated}"
+    fi
+}
+
+duplicates target_resources.json '"\(.kind)/\(.res_uuid)"' "target resources"
+duplicates resources.json '"\(.kind)/\(.res_uuid)"' "actual resources"
+duplicates elements.json '"\(.name)/\(.version)"' "elements"
+
+# Everything installed before must still be installed.  The core itself is
+# excluded: replacing its row with a new version is the point of the upgrade.
+missing_elements="$(
+    jq -r -n \
+        --slurpfile before "${before_dir}/elements.json" \
+        --slurpfile after "${after_dir}/elements.json" \
+        '($after[0] | map(.name) | unique) as $present
+         | $before[0] | map(select(.name != "core") | .name) | unique
+         | map(select(. as $name | $present | index($name) | not))
+         | .[]'
+)"
+if [[ -n "${missing_elements}" ]]; then
+    fail "elements lost during the upgrade: ${missing_elements//$'\n'/, }"
+fi
+
+before_nodes="$(jq -r '.nodes' "${before_dir}/counts.json")"
+after_nodes="$(jq -r '.nodes' "${after_dir}/counts.json")"
+if ((after_nodes < before_nodes)); then
+    fail "compute nodes disappeared: ${before_nodes} -> ${after_nodes}"
+fi
+
+log "counts before: $(tr -d '\n ' <"${before_dir}/counts.json")"
+log "counts after:  $(tr -d '\n ' <"${after_dir}/counts.json")"
+
+((failures == 0)) || die "${failures} snapshot comparison(s) failed"
+log "no objects were lost or duplicated by the upgrade"

--- a/tools/ci/upgrade/lib.sh
+++ b/tools/ci/upgrade/lib.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+# Shared helpers for the core upgrade end-to-end CI job.
+#
+# The job bootstraps the previous release, puts a workload on it, upgrades the
+# core to the freshly built version and then asserts that the installation both
+# survived and converged.
+#
+# Actions go through the `exordos` CLI, because that is what a real operator
+# uses.  Assertions go through the raw user API, so that they depend on the API
+# contract rather than on how the CLI happens to render a table today.
+
+set -euo pipefail
+
+CORE_ENDPOINT_URL="${CORE_ENDPOINT_URL:-http://10.20.0.2:80/api/core}"
+CORE_USERNAME="${CORE_USERNAME:-admin}"
+CORE_PASSWORD="${CORE_PASSWORD:-admin}"
+CORE_CLIENT="${CORE_CLIENT:-default}"
+
+# The workload uses deterministic names so that the "seed" and "verify" phases
+# need no state passed between workflow steps.
+MARKER_ORGANIZATION="upgrade-e2e-organization"
+MARKER_PROJECT="upgrade-e2e-project"
+MARKER_PROJECT_AFTER="upgrade-e2e-project-after"
+MARKER_PG_INSTANCE="upgrade-e2e-pg"
+MARKER_PG_USER="upgrade_e2e_user"
+MARKER_PG_PASSWORD="upgrade-e2e-password"
+MARKER_PG_DATABASE="upgrade_e2e_db"
+MARKER_TABLE="upgrade_marker"
+
+DBAAS_ELEMENT="${DBAAS_ELEMENT:-dbaas}"
+DBAAS_API_PORT="${DBAAS_API_PORT:-8080}"
+
+log() { printf '[%(%H:%M:%S)T] %s\n' -1 "$*" >&2; }
+
+die() {
+    log "FAILED: $*"
+    exit 1
+}
+
+# --- API access --------------------------------------------------------------
+
+_core_token=""
+_core_token_issued_at=0
+
+# Tokens are short lived and the job outlives them, so re-issue periodically.
+#
+# This must not abort the process on failure: the API is legitimately gone
+# while the core replaces its image and reboots, and the wait loops need a
+# plain non-zero result to keep polling.
+core_token() {
+    local now
+    now="$(date +%s)"
+    if [[ -z "${_core_token}" ]] || ((now - _core_token_issued_at > 240)); then
+        _core_token="$(
+            curl -fsS -X POST \
+                "${CORE_ENDPOINT_URL}/v1/iam/clients/${CORE_CLIENT}/actions/get_token/invoke" \
+                -H 'Content-Type: application/x-www-form-urlencoded' \
+                --data-urlencode "username=${CORE_USERNAME}" \
+                --data-urlencode "password=${CORE_PASSWORD}" \
+                --data-urlencode 'grant_type=password' |
+                jq -er '.access_token'
+        )" || return 1
+        _core_token_issued_at="${now}"
+    fi
+    printf '%s' "${_core_token}"
+}
+
+api_get() { # <base_url> <path>
+    curl -fsS -H "Authorization: Bearer $(core_token)" "${1}${2}"
+}
+
+api_post() { # <base_url> <path> <json_body>
+    curl -fsS -X POST \
+        -H "Authorization: Bearer $(core_token)" \
+        -H 'Content-Type: application/json' \
+        --data "${3}" \
+        "${1}${2}"
+}
+
+core_get() { api_get "${CORE_ENDPOINT_URL}" "$1"; }
+
+core_post() { api_post "${CORE_ENDPOINT_URL}" "$1" "$2"; }
+
+# --- waiting -----------------------------------------------------------------
+
+# wait_for <timeout_s> <interval_s> <description> <command...>
+#
+# The command is expected to be quiet; redirect inside the predicate if needed.
+wait_for() {
+    local timeout="$1" interval="$2" description="$3"
+    shift 3
+
+    local deadline=$((SECONDS + timeout))
+    while ((SECONDS < deadline)); do
+        if "$@"; then
+            log "ok: ${description}"
+            return 0
+        fi
+        sleep "${interval}"
+    done
+    die "timed out after ${timeout}s waiting for: ${description}"
+}
+
+core_api_is_up() {
+    core_get "/v1/em/elements/" >/dev/null 2>&1
+}
+
+# element_is_active <name> [version]
+#
+# Every row for the element must be ACTIVE, and at least one row must exist —
+# an element with no rows is a missing element, not a converged one.
+element_is_active() {
+    local name="$1" version="${2:-}" verdict
+    verdict="$(
+        core_get "/v1/em/elements/?name=${name}" 2>/dev/null |
+            jq -r --arg version "${version}" '
+                map(select($version == "" or .version == $version))
+                | if length == 0 then "MISSING"
+                  elif all(.status == "ACTIVE") then "ACTIVE"
+                  else "PENDING" end
+            '
+    )" || return 1
+    [[ "${verdict}" == "ACTIVE" ]]
+}
+
+# --- repositories ------------------------------------------------------------
+
+# Repository listings are only as fresh as the last refresh, and both what to
+# install and what to upgrade to are read from them.
+refresh_repositories() {
+    local uuid
+    for uuid in $(core_get /v1/repo/repositories/ | jq -r '.[].uuid'); do
+        core_post "/v1/repo/repositories/${uuid}/actions/refresh/invoke" '{}' >/dev/null ||
+            log "warning: cannot refresh repository ${uuid}"
+    done
+}
+
+# --- element lookups ---------------------------------------------------------
+
+element_uuid() { # <name>
+    core_get "/v1/em/elements/?name=${1}" | jq -er '.[0].uuid' ||
+        die "element ${1} is not installed"
+}
+
+# Nodes an element owns, as "<name> <ipv4>" lines.
+element_node_addresses() { # <name>
+    local uuid node_uuid
+    uuid="$(element_uuid "$1")"
+    for node_uuid in $(
+        core_get "/v1/em/elements/${uuid}/resources/?kind=em_core_compute_nodes" |
+            jq -r '.[].uuid'
+    ); do
+        core_get "/v1/compute/nodes/${node_uuid}" |
+            jq -r '"\(.name) \(.default_network.ipv4 // "")"'
+    done
+}
+
+# The element's API endpoint, found by probing its nodes rather than by
+# guessing which node holds the control plane.
+dbaas_api_url() {
+    local name address url
+    while read -r name address; do
+        [[ -n "${address}" ]] || continue
+        url="http://${address}:${DBAAS_API_PORT}"
+        if api_get "${url}" "/v1/types/postgres/versions/" >/dev/null 2>&1; then
+            printf '%s' "${url}"
+            return 0
+        fi
+        log "node ${name} (${address}) does not serve the dbaas API"
+    done < <(element_node_addresses "${DBAAS_ELEMENT}")
+    die "no node of element ${DBAAS_ELEMENT} serves the API on port ${DBAAS_API_PORT}"
+}

--- a/tools/ci/upgrade/lib.sh
+++ b/tools/ci/upgrade/lib.sh
@@ -38,6 +38,12 @@ CORE_CLIENT="${CORE_CLIENT:-default}"
 MARKER_ORGANIZATION="upgrade-e2e-organization"
 MARKER_PROJECT="upgrade-e2e-project"
 MARKER_PROJECT_AFTER="upgrade-e2e-project-after"
+# `project_id` is required and has no default: restalchemy declares it
+# read-only with no fallback, so project-scoped resources take it in the
+# payload — the same way `exordos cn add` demands `--project-id`. The service
+# project is the one the installation already runs its own nodes in, so it is
+# known to have quota; a freshly created tenant project would not be.
+MARKER_PROJECT_ID="00000000-0000-0000-0000-000000000000"
 MARKER_PG_INSTANCE="upgrade-e2e-pg"
 MARKER_PG_USER="upgrade_e2e_user"
 MARKER_PG_PASSWORD="upgrade-e2e-password"
@@ -82,17 +88,47 @@ core_token() {
     printf '%s' "${_core_token}"
 }
 
-api_get() { # <base_url> <path>
-    curl -fsS -H "Authorization: Bearer $(core_token)" "${1}${2}"
+# api_request <method> <base_url> <path> [json_body]
+#
+# `curl -f` throws the response body away, which turns every rejected payload
+# into a bare "error 400" and leaves nothing to debug. Capture the body and
+# print it instead. Callers that poll silence stderr, so this stays quiet
+# exactly where failures are expected.
+api_request() {
+    local method="$1" base="$2" path="$3" body="${4:-}"
+    local response status
+    response="$(mktemp)"
+
+    local -a args=(
+        -sS -o "${response}" -w '%{http_code}'
+        -X "${method}"
+        -H "Authorization: Bearer $(core_token)"
+    )
+    if [[ -n "${body}" ]]; then
+        args+=(-H 'Content-Type: application/json' --data "${body}")
+    fi
+
+    if ! status="$(curl "${args[@]}" "${base}${path}")"; then
+        log "${method} ${path}: no response from ${base}"
+        rm -f "${response}"
+        return 1
+    fi
+
+    if ((status >= 400)); then
+        log "${method} ${path}: HTTP ${status}"
+        log "  request:  ${body:-<empty>}"
+        log "  response: $(tr -d '\n' <"${response}")"
+        rm -f "${response}"
+        return 1
+    fi
+
+    cat "${response}"
+    rm -f "${response}"
 }
 
-api_post() { # <base_url> <path> <json_body>
-    curl -fsS -X POST \
-        -H "Authorization: Bearer $(core_token)" \
-        -H 'Content-Type: application/json' \
-        --data "${3}" \
-        "${1}${2}"
-}
+api_get() { api_request GET "$1" "$2"; }
+
+api_post() { api_request POST "$1" "$2" "$3"; }
 
 core_get() { api_get "${CORE_ENDPOINT_URL}" "$1"; }
 

--- a/tools/ci/upgrade/resolve-versions.sh
+++ b/tools/ci/upgrade/resolve-versions.sh
@@ -54,10 +54,19 @@ prev_version="$(
 [[ -n "${prev_version}" ]] ||
     die "no release tag to upgrade from (fetch tags: actions/checkout needs fetch-tags)"
 
-# On a branch cut before a release tag landed, the newest tag can be *newer*
-# than what this run built, and the test would quietly run backwards.
-[[ "$(printf '%s\n%s\n' "${prev_version}" "${new_version}" | sort -V | head -n 1)" == "${prev_version}" ]] ||
+# The built version is the nearest reachable tag with its patch bumped, so it
+# should always outrank every existing tag. When it does not, the build was
+# labelled from a history that was missing tags — a shallow or tagless fetch,
+# or a self-hosted runner reusing an old working directory — and upgrading to
+# it would run the test backwards. Say which tags were visible, because that is
+# the evidence needed to tell a mislabelled build from a genuinely odd branch.
+if [[ "$(printf '%s\n%s\n' "${prev_version}" "${new_version}" | sort -V | head -n 1)" != "${prev_version}" ]]; then
+    log "release tags visible here: $(
+        git tag --list --sort=-v:refname | grep -Ex '[0-9]+\.[0-9]+\.[0-9]+' | head -n 5 | tr '\n' ' '
+    )"
+    log "the built version comes from the nearest tag reachable at build time, patch + 1"
     die "the newest release tag ${prev_version} is newer than the built version ${new_version}"
+fi
 
 # The image of the base release has to exist, otherwise the job would fail
 # later inside bootstrap with a much less obvious error.  This deliberately

--- a/tools/ci/upgrade/resolve-versions.sh
+++ b/tools/ci/upgrade/resolve-versions.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+# Resolve the version pair for the upgrade test and make sure the base release
+# can actually be installed.
+#
+#   NEW  - the version this run built, taken from the build artifacts.
+#   PREV - the newest release tag that is not NEW; this is what an existing
+#          installation is expected to be running.
+#
+# Usage: resolve-versions.sh <path-to-version.txt>
+#
+# Writes prev/new to $GITHUB_OUTPUT when running under Actions, and always
+# prints them.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/ci/upgrade/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+ELEMENTS_REPO_URL="${ELEMENTS_REPO_URL:-https://repo.exordos.com/exordos-elements}"
+CORE_IMAGE_NAME="${CORE_IMAGE_NAME:-exordos-core.raw.zst}"
+
+version_file="${1:?usage: resolve-versions.sh <path-to-version.txt>}"
+
+new_version="$(tr -d '[:space:]' <"${version_file}")"
+[[ -n "${new_version}" ]] || die "${version_file} is empty"
+
+# `git tag --sort=-v:refname` orders newest first; the pattern keeps release
+# tags only, so the `backup/*` tags cannot win.
+prev_version="$(
+    git tag --list --sort=-v:refname |
+        grep -Ex '[0-9]+\.[0-9]+\.[0-9]+' |
+        grep -vFx "${new_version}" |
+        head -n 1
+)" || true
+
+[[ -n "${prev_version}" ]] ||
+    die "no release tag to upgrade from (fetch tags: actions/checkout needs fetch-tags)"
+
+# On a branch cut before a release tag landed, the newest tag can be *newer*
+# than what this run built, and the test would quietly run backwards.
+[[ "$(printf '%s\n%s\n' "${prev_version}" "${new_version}" | sort -V | head -n 1)" == "${prev_version}" ]] ||
+    die "the newest release tag ${prev_version} is newer than the built version ${new_version}"
+
+# The image of the base release has to exist, otherwise the job would fail
+# later inside bootstrap with a much less obvious error.  This deliberately
+# fails the job instead of skipping: a silent skip turns the whole test into a
+# green light that checks nothing.
+base_image_url="${ELEMENTS_REPO_URL}/core/${prev_version}/images/${CORE_IMAGE_NAME}"
+curl -fsS --head "${base_image_url}" >/dev/null ||
+    die "base release image is not published: ${base_image_url}"
+
+log "upgrading ${prev_version} -> ${new_version}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+        printf 'prev=%s\n' "${prev_version}"
+        printf 'new=%s\n' "${new_version}"
+    } >>"${GITHUB_OUTPUT}"
+fi
+
+printf 'prev=%s new=%s\n' "${prev_version}" "${new_version}"

--- a/tools/ci/upgrade/snapshot.sh
+++ b/tools/ci/upgrade/snapshot.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+# Dump the parts of the installation the upgrade must not damage.
+#
+# Usage: snapshot.sh <directory>
+#
+# The files are compared by compare-snapshots.sh and uploaded as job artifacts,
+# so that a failure can be diagnosed without re-running the whole job.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/ci/upgrade/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+target_dir="${1:?usage: snapshot.sh <directory>}"
+mkdir -p "${target_dir}"
+
+dump() { # <file> <api path>
+    core_get "$2" | jq -S '.' >"${target_dir}/$1"
+}
+
+dump elements.json /v1/em/elements/
+dump target_resources.json /v1/ua/target_resources/
+dump resources.json /v1/ua/resources/
+dump agents.json /v1/ua/agents/
+dump nodes.json /v1/compute/nodes/
+dump projects.json /v1/iam/projects/
+dump organizations.json /v1/iam/organizations/
+
+jq -n \
+    --slurpfile elements "${target_dir}/elements.json" \
+    --slurpfile targets "${target_dir}/target_resources.json" \
+    --slurpfile actual "${target_dir}/resources.json" \
+    --slurpfile nodes "${target_dir}/nodes.json" \
+    '{
+        elements: ($elements[0] | length),
+        target_resources: ($targets[0] | length),
+        resources: ($actual[0] | length),
+        nodes: ($nodes[0] | length)
+    }' >"${target_dir}/counts.json"
+
+log "snapshot written to ${target_dir}: $(tr -d '\n ' <"${target_dir}/counts.json")"

--- a/tools/ci/upgrade/upgrade-core.sh
+++ b/tools/ci/upgrade/upgrade-core.sh
@@ -35,6 +35,25 @@ source "${SCRIPT_DIR}/lib.sh"
 
 API_RETURN_TIMEOUT="${UPGRADE_API_RETURN_TIMEOUT:-900}"
 CORE_ACTIVE_TIMEOUT="${UPGRADE_CORE_ACTIVE_TIMEOUT:-900}"
+REIMAGE_TIMEOUT="${UPGRADE_REIMAGE_TIMEOUT:-900}"
+
+# The set every core node belongs to (`exordos_core.common.constants`).
+CORE_SET_UUID="70c88222-b4d9-46c3-9340-aa5bfaaa4b94"
+
+core_node_uuid() {
+    core_get /v1/compute/nodes/ |
+        jq -er --arg set "${CORE_SET_UUID}" \
+            'map(select((.node_set // "") | contains($set))) | .[0].uuid'
+}
+
+# What the data plane last reported for the core node's machine. `hash` covers
+# the target fields, and the image is one of them, so this changes exactly when
+# the machine is running a different image than it was.
+core_machine_hash() { # <node uuid>
+    core_get /v1/ua/resources/ 2>/dev/null |
+        jq -er --arg node "$1" \
+            'map(select(.kind == "guest_machine" and .node == $node)) | .[0].hash'
+}
 
 new_version="${1:?usage: upgrade-core.sh <new-version>}"
 
@@ -62,13 +81,37 @@ MISSING)
     ;;
 esac
 
+# Recorded before the update, because the point of it is to change.
+core_node="$(core_node_uuid)" || die "cannot find this installation's core node"
+image_before="$(core_machine_hash "${core_node}")" ||
+    die "the core node's machine is not reported by any agent"
+
 log "upgrading core to ${new_version}"
 started_at="${SECONDS}"
 exordos ee update core -v "${new_version}" -y
 
 # The API disappears while the image is replaced and the machine reboots.
 wait_for "${API_RETURN_TIMEOUT}" 5 "the core API to come back" core_api_is_up
-log "core API was unavailable for about $((SECONDS - started_at))s"
+
+# ...but "the API answers" is not "the upgrade happened". The element row flips
+# to the new version, and the API keeps serving, for as long as it takes the
+# machine to be told to re-image itself: measured on a stand, the row was ACTIVE
+# and the API up 4s after `ee update` returned, while the real outage started a
+# minute later and lasted about two and a half. A job that believed the first
+# signal declared success, went on to snapshot an installation still running the
+# old image, and then died on a 502 when the reboot finally came.
+#
+# The machine having been re-imaged is a data-plane fact, so ask the data plane:
+# the core node's `guest_machine` resource is re-reported with a different hash
+# once the agent has applied the new image, and cannot say so before.
+image_changed() {
+    local now
+    now="$(core_machine_hash "${core_node}")" || return 1
+    [[ "${now}" != "${image_before}" ]]
+}
+wait_for "${REIMAGE_TIMEOUT}" 10 \
+    "the core node's machine to report a new image" image_changed
+log "core was replaced and came back after about $((SECONDS - started_at))s"
 
 wait_for "${CORE_ACTIVE_TIMEOUT}" 10 "core ${new_version} to become ACTIVE" \
     element_is_active core "${new_version}"

--- a/tools/ci/upgrade/upgrade-core.sh
+++ b/tools/ci/upgrade/upgrade-core.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+# Upgrade the core of a running installation and wait for it to come back.
+#
+# Usage: upgrade-core.sh <new-version>
+#
+# The core replaces its own image and reboots, and there is no way back if the
+# new image cannot be fetched: the update data is moved off the data disk
+# before the download is attempted, so a failed download leaves a machine that
+# boots into an updater with nothing to apply.  The installation here is
+# disposable, but the preconditions are still checked up front so that a
+# failure says what went wrong instead of hanging until the job times out.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/ci/upgrade/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+API_RETURN_TIMEOUT="${UPGRADE_API_RETURN_TIMEOUT:-900}"
+CORE_ACTIVE_TIMEOUT="${UPGRADE_CORE_ACTIVE_TIMEOUT:-900}"
+
+new_version="${1:?usage: upgrade-core.sh <new-version>}"
+
+# The version to upgrade to is read from a repository listing, which is only as
+# fresh as the last refresh.
+refresh_repositories
+
+# `ee update -v` only considers repository rows in AVAILABLE state, so a
+# version that is not offered — or is already installed — silently has nothing
+# to update to.
+offered_status="$(
+    core_get "/v1/repo/elements/?name=core" |
+        jq -r --arg version "${new_version}" '
+            map(select(.version == $version)) | .[0].status // "MISSING"
+        '
+)"
+case "${offered_status}" in
+AVAILABLE) ;;
+MISSING)
+    core_get "/v1/repo/elements/?name=core" | jq -r '.[] | "  \(.version) \(.status)"' >&2
+    die "core ${new_version} is not offered by any repository (see the versions above)"
+    ;;
+*)
+    die "core ${new_version} is in state ${offered_status}, not AVAILABLE — nothing to update to"
+    ;;
+esac
+
+log "upgrading core to ${new_version}"
+started_at="${SECONDS}"
+exordos ee update core -v "${new_version}" -y
+
+# The API disappears while the image is replaced and the machine reboots.
+wait_for "${API_RETURN_TIMEOUT}" 5 "the core API to come back" core_api_is_up
+log "core API was unavailable for about $((SECONDS - started_at))s"
+
+wait_for "${CORE_ACTIVE_TIMEOUT}" 10 "core ${new_version} to become ACTIVE" \
+    element_is_active core "${new_version}"
+
+# A stale row left behind is worth reporting; a second *active* core is a
+# broken upgrade, not leftovers.
+core_get "/v1/em/elements/?name=core" | jq -r '.[] | "  core \(.version) \(.status)"' >&2
+other_active="$(
+    core_get "/v1/em/elements/?name=core" |
+        jq -r --arg version "${new_version}" '
+            map(select(.version != $version and .status == "ACTIVE") | .version)
+            | unique | join(", ")
+        '
+)"
+[[ -z "${other_active}" ]] ||
+    die "core ${new_version} is ACTIVE, but so are older versions: ${other_active}"

--- a/tools/ci/upgrade/workload.sh
+++ b/tools/ci/upgrade/workload.sh
@@ -127,8 +127,10 @@ seed_element_data() {
     api_post "${api_url}" /v1/types/postgres/instances/ "$(
         jq -n \
             --arg name "${MARKER_PG_INSTANCE}" \
+            --arg project_id "${MARKER_PROJECT_ID}" \
             --arg version "/v1/types/postgres/versions/${version}" \
-            '{name: $name, version: $version, cpu: 1, ram: 2048, disk_size: 8,
+            '{name: $name, project_id: $project_id, version: $version,
+              cpu: 1, ram: 2048, disk_size: 8,
               nodes_number: 1, sync_replica_number: 0}'
     )" >/dev/null
 
@@ -138,8 +140,11 @@ seed_element_data() {
     instance_uuid="$(pg_instance "${api_url}" | jq -er '.uuid')"
 
     api_post "${api_url}" "/v1/types/postgres/instances/${instance_uuid}/users/" "$(
-        jq -n --arg name "${MARKER_PG_USER}" --arg password "${MARKER_PG_PASSWORD}" \
-            '{name: $name, password: $password}'
+        jq -n \
+            --arg name "${MARKER_PG_USER}" \
+            --arg project_id "${MARKER_PROJECT_ID}" \
+            --arg password "${MARKER_PG_PASSWORD}" \
+            '{name: $name, project_id: $project_id, password: $password}'
     )" >/dev/null
     user_uuid="$(
         api_get "${api_url}" "/v1/types/postgres/instances/${instance_uuid}/users/" |
@@ -149,8 +154,9 @@ seed_element_data() {
     api_post "${api_url}" "/v1/types/postgres/instances/${instance_uuid}/databases/" "$(
         jq -n \
             --arg name "${MARKER_PG_DATABASE}" \
+            --arg project_id "${MARKER_PROJECT_ID}" \
             --arg owner "/v1/types/postgres/instances/${instance_uuid}/users/${user_uuid}" \
-            '{name: $name, owner: $owner}'
+            '{name: $name, project_id: $project_id, owner: $owner}'
     )" >/dev/null
 
     host="$(pg_instance_address "${api_url}")"

--- a/tools/ci/upgrade/workload.sh
+++ b/tools/ci/upgrade/workload.sh
@@ -189,12 +189,20 @@ verify_element_data() {
     [[ "${before}" == "1" ]] ||
         die "the pre-upgrade marker row is gone (found ${before} rows)"
 
+    # Count first, then insert, then count again. Asserting the total is 1
+    # conflates "the write worked" with "this script has run once", and the
+    # second is not what is being tested: re-running `verify` is the ordinary
+    # thing to do while diagnosing an upgrade that went wrong, and it used to
+    # fail on its own previous run.
+    local written
+    written="$(psql_marker "${host}" \
+        "SELECT count(*) FROM ${MARKER_TABLE} WHERE note = 'after upgrade'")"
     psql_marker "${host}" \
         "INSERT INTO ${MARKER_TABLE} (note) VALUES ('after upgrade')" >/dev/null
     after="$(psql_marker "${host}" \
         "SELECT count(*) FROM ${MARKER_TABLE} WHERE note = 'after upgrade'")"
-    [[ "${after}" == "1" ]] ||
-        die "cannot write to the database after the upgrade (found ${after} rows)"
+    [[ "${after}" == "$((written + 1))" ]] ||
+        die "cannot write to the database after the upgrade (${written} rows before the insert, ${after} after)"
 
     log "element data survived and the database still accepts writes"
 }

--- a/tools/ci/upgrade/workload.sh
+++ b/tools/ci/upgrade/workload.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Genesis Corporation
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+# The workload the upgrade has to survive.
+#
+#   seed   - put load on the freshly bootstrapped previous release: core-level
+#            data (an organization and a project), a third-party element
+#            (dbaas) with its own nodes, and a real row in a database the
+#            element provisioned.
+#   verify - after the upgrade, assert that all of it survived AND that the
+#            paths are still alive: new objects can be created, new rows can be
+#            written.  Surviving data alone would not prove the control plane
+#            still works.
+#
+# Usage: workload.sh seed|verify
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/ci/upgrade/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+ELEMENT_TIMEOUT="${UPGRADE_ELEMENT_TIMEOUT:-2400}"
+INSTANCE_TIMEOUT="${UPGRADE_INSTANCE_TIMEOUT:-2400}"
+
+# --- core-level data ---------------------------------------------------------
+
+organization_uuid() {
+    core_get "/v1/iam/organizations/?name=${MARKER_ORGANIZATION}" | jq -er '.[0].uuid'
+}
+
+project_uuid() { # <name>
+    core_get "/v1/iam/projects/?name=${1}" | jq -er '.[0].uuid'
+}
+
+create_project() { # <name> <organization uuid>
+    core_post /v1/iam/projects/ "$(
+        jq -n --arg name "$1" --arg organization "/v1/iam/organizations/$2" \
+            '{name: $name, organization: $organization}'
+    )" >/dev/null
+}
+
+seed_core_data() {
+    log "creating core-level marker objects"
+    core_post /v1/iam/organizations/ \
+        "$(jq -n --arg name "${MARKER_ORGANIZATION}" '{name: $name}')" >/dev/null
+    create_project "${MARKER_PROJECT}" "$(organization_uuid)"
+}
+
+verify_core_data() {
+    local organization project
+    organization="$(organization_uuid)" ||
+        die "organization ${MARKER_ORGANIZATION} did not survive the upgrade"
+    project="$(project_uuid "${MARKER_PROJECT}")" ||
+        die "project ${MARKER_PROJECT} did not survive the upgrade"
+    log "core-level markers survived (organization=${organization} project=${project})"
+
+    # Data surviving is not enough: the write path has to work afterwards too.
+    create_project "${MARKER_PROJECT_AFTER}" "${organization}" ||
+        die "cannot create a project after the upgrade"
+    project_uuid "${MARKER_PROJECT_AFTER}" >/dev/null ||
+        die "project created after the upgrade is not readable back"
+    log "core write path works after the upgrade"
+}
+
+# --- third-party element -----------------------------------------------------
+
+seed_element() {
+    log "installing element ${DBAAS_ELEMENT}"
+    refresh_repositories
+    core_get "/v1/repo/elements/?name=${DBAAS_ELEMENT}" | jq -e 'length > 0' >/dev/null ||
+        die "element ${DBAAS_ELEMENT} is not offered by any repository"
+
+    exordos ee install "${DBAAS_ELEMENT}"
+    wait_for "${ELEMENT_TIMEOUT}" 15 "element ${DBAAS_ELEMENT} to become ACTIVE" \
+        element_is_active "${DBAAS_ELEMENT}"
+}
+
+# --- data inside the element -------------------------------------------------
+
+pg_instance() { # <dbaas api url>
+    api_get "$1" "/v1/types/postgres/instances/?name=${MARKER_PG_INSTANCE}" | jq -er '.[0]'
+}
+
+pg_instance_is_active() { # <dbaas api url>
+    [[ "$(pg_instance "$1" 2>/dev/null | jq -r '.status // "MISSING"')" == "ACTIVE" ]]
+}
+
+pg_instance_address() { # <dbaas api url>
+    pg_instance "$1" | jq -er '.ipsv4[0]'
+}
+
+psql_marker() { # <host> <sql>
+    PGPASSWORD="${MARKER_PG_PASSWORD}" psql \
+        --host "$1" --username "${MARKER_PG_USER}" --dbname "${MARKER_PG_DATABASE}" \
+        --no-align --tuples-only --quiet --set ON_ERROR_STOP=1 --command "$2"
+}
+
+pg_is_reachable() { # <host>
+    psql_marker "$1" 'SELECT 1' >/dev/null 2>&1
+}
+
+seed_element_data() {
+    local api_url version instance_uuid user_uuid host
+    api_url="$(dbaas_api_url)"
+    log "dbaas API at ${api_url}"
+
+    version="$(api_get "${api_url}" /v1/types/postgres/versions/ | jq -er '.[0].uuid')" ||
+        die "dbaas offers no postgres versions"
+
+    log "creating postgres instance ${MARKER_PG_INSTANCE}"
+    api_post "${api_url}" /v1/types/postgres/instances/ "$(
+        jq -n \
+            --arg name "${MARKER_PG_INSTANCE}" \
+            --arg version "/v1/types/postgres/versions/${version}" \
+            '{name: $name, version: $version, cpu: 1, ram: 2048, disk_size: 8,
+              nodes_number: 1, sync_replica_number: 0}'
+    )" >/dev/null
+
+    wait_for "${INSTANCE_TIMEOUT}" 15 "postgres instance to become ACTIVE" \
+        pg_instance_is_active "${api_url}"
+
+    instance_uuid="$(pg_instance "${api_url}" | jq -er '.uuid')"
+
+    api_post "${api_url}" "/v1/types/postgres/instances/${instance_uuid}/users/" "$(
+        jq -n --arg name "${MARKER_PG_USER}" --arg password "${MARKER_PG_PASSWORD}" \
+            '{name: $name, password: $password}'
+    )" >/dev/null
+    user_uuid="$(
+        api_get "${api_url}" "/v1/types/postgres/instances/${instance_uuid}/users/" |
+            jq -er --arg name "${MARKER_PG_USER}" '.[] | select(.name == $name) | .uuid'
+    )"
+
+    api_post "${api_url}" "/v1/types/postgres/instances/${instance_uuid}/databases/" "$(
+        jq -n \
+            --arg name "${MARKER_PG_DATABASE}" \
+            --arg owner "/v1/types/postgres/instances/${instance_uuid}/users/${user_uuid}" \
+            '{name: $name, owner: $owner}'
+    )" >/dev/null
+
+    host="$(pg_instance_address "${api_url}")"
+    wait_for 600 10 "postgres at ${host} to accept the marker connection" \
+        pg_is_reachable "${host}"
+
+    log "writing the marker row"
+    psql_marker "${host}" "
+        CREATE TABLE IF NOT EXISTS ${MARKER_TABLE} (
+            id serial PRIMARY KEY,
+            note text NOT NULL,
+            created_at timestamptz NOT NULL DEFAULT now()
+        );
+        INSERT INTO ${MARKER_TABLE} (note) VALUES ('before upgrade');
+    " >/dev/null
+}
+
+verify_element_data() {
+    local api_url host before after
+    element_is_active "${DBAAS_ELEMENT}" ||
+        die "element ${DBAAS_ELEMENT} is not ACTIVE after the upgrade"
+
+    api_url="$(dbaas_api_url)"
+    pg_instance_is_active "${api_url}" ||
+        die "postgres instance ${MARKER_PG_INSTANCE} is not ACTIVE after the upgrade"
+
+    host="$(pg_instance_address "${api_url}")"
+    before="$(psql_marker "${host}" \
+        "SELECT count(*) FROM ${MARKER_TABLE} WHERE note = 'before upgrade'")"
+    [[ "${before}" == "1" ]] ||
+        die "the pre-upgrade marker row is gone (found ${before} rows)"
+
+    psql_marker "${host}" \
+        "INSERT INTO ${MARKER_TABLE} (note) VALUES ('after upgrade')" >/dev/null
+    after="$(psql_marker "${host}" \
+        "SELECT count(*) FROM ${MARKER_TABLE} WHERE note = 'after upgrade'")"
+    [[ "${after}" == "1" ]] ||
+        die "cannot write to the database after the upgrade (found ${after} rows)"
+
+    log "element data survived and the database still accepts writes"
+}
+
+# --- entry point -------------------------------------------------------------
+
+case "${1:?usage: workload.sh seed|verify}" in
+seed)
+    seed_core_data
+    seed_element
+    seed_element_data
+    log "workload is in place"
+    ;;
+verify)
+    verify_core_data
+    verify_element_data
+    log "workload survived the upgrade"
+    ;;
+*)
+    die "unknown command: $1"
+    ;;
+esac


### PR DESCRIPTION
## Summary by Sourcery

Add an end-to-end CI job that verifies upgrading Exordos Core from the latest released version to the newly built version and ensures existing installations remain healthy.

New Features:
- Provide reusable shell scripts under tools/ci/upgrade for version resolution, workload setup/verification, snapshotting, convergence checking, core upgrade orchestration, and snapshot comparison.

Enhancements:
- Ensure build artifacts are tagged correctly by fetching full git history on the self-hosted runner.

CI:
- Extend the main build workflow to trigger on PR openings (excluding docs-only changes) and to skip untrusted fork builds on the self-hosted runner.
- Introduce an UpgradeE2E job that bootstraps the previous release, upgrades core to the newly built version, and runs convergence, snapshot, and workload survival checks.

Documentation:
- Document the upgrade testing strategy and CI job in the core developer guide, including scope, assertions, and limitations.

Tests:
- Add upgrade test tooling that seeds a realistic workload, snapshots control- and data-plane state, checks convergence via hash comparisons, upgrades core, and compares pre/post-upgrade snapshots to detect regressions.