### PR TITLE
do not publish example manifests

### DIFF
--- a/exordos/exordos.yaml
+++ b/exordos/exordos.yaml
@@ -74,5 +74,3 @@ build:
           flatten: true
           artifacts:
             - ../exordos_docs/
-    - manifest: manifests/core-node-set-example.yaml.j2
-    - manifest: manifests/core-service-example.yaml.j2

--- a/exordos/manifests/examples/core-node-set-example.yaml
+++ b/exordos/manifests/examples/core-node-set-example.yaml
@@ -1,7 +1,7 @@
 name: "core-node-set-example"
 description: "Exordos Core node & set example"
 schema_version: 1
-version: "{{ version }}"
+version: "1.0.0"
 api_version: "v1"
 
 requirements:

--- a/exordos/manifests/examples/core-service-example.yaml
+++ b/exordos/manifests/examples/core-service-example.yaml
@@ -1,7 +1,7 @@
 name: "core-service-example"
 description: "Exordos Core Service Example"
 schema_version: 1
-version: "{{ version }}"
+version: "1.0.0"
 api_version: "v1"
 
 requirements:


### PR DESCRIPTION
## Summary by Sourcery

Remove example manifests from the build output while retaining them as non-templated, version-pinned examples under an examples directory.

New Features:
- Provide static example core node set and core service manifests with a fixed schema version in an examples directory.

Enhancements:
- Stop treating example manifests as Jinja-templated files by converting them to plain YAML with a fixed version field.
- Reorganize example manifests into a dedicated examples directory to clarify their non-production, reference-only status.