### PR TITLE
Add realm-scoped sync-only DNS domains

### DIFF
--- a/exordos/manifests/specification/full_spec.yaml
+++ b/exordos/manifests/specification/full_spec.yaml
@@ -526,6 +526,17 @@ components:
           format: uuid
           readOnly: true
           type: string
+        realm_id:
+          example: ^[0-9a-f]{6,32}$
+          nullable: true
+          pattern: ^[0-9a-f]{6,32}$
+          readOnly: true
+          type: string
+        sync_only:
+          default: false
+          example: true
+          readOnly: true
+          type: boolean
         sync_to_ecosystem:
           default: false
           example: true
@@ -2321,6 +2332,10 @@ components:
           example: true
           type: boolean
         domain:
+          type: string
+        full_name:
+          example: any_string
+          readOnly: true
           type: string
         name:
           example: any_string

--- a/exordos_core/bootstrap/defaults.py
+++ b/exordos_core/bootstrap/defaults.py
@@ -33,6 +33,7 @@ from exordos_core.compute import constants as nc
 from exordos_core.compute.dm import models as compute_models
 from exordos_core.compute.node_set.dm import models as node_set_models
 from exordos_core.secret import utils as secret_utils
+from exordos_core.user_api.dns.dm import models as dns_models
 from exordos_core.user_api.iam.dm import models as iam_models
 from exordos_core.vs.dm import models as vs_models
 
@@ -553,6 +554,49 @@ def set_realm_secret_var(spec: dict[str, tp.Any]) -> bool:
         project_id=c.EM_HIDDEN_PROJECT_ID,
     )
     realm_secret_val.insert()
+    return True
+
+
+def ensure_realm_dns_domain(spec: dict[str, tp.Any]) -> bool:
+    realm_id = spec.get("realm_id")
+    realm_domain = spec.get("realm_domain")
+    if realm_id is None and realm_domain is None:
+        return True
+    if not realm_id or not realm_domain:
+        raise RuntimeError("realm_id and realm_domain must be provided together")
+
+    realm_id = str(realm_id).lower()
+    realm_domain = str(realm_domain).lower().rstrip(".")
+    prefix = f"{realm_id}."
+    if not realm_domain.startswith(prefix):
+        raise RuntimeError("realm_domain does not match realm_id")
+
+    domain_name = realm_domain.removeprefix(prefix)
+    if not domain_name:
+        raise RuntimeError("realm_domain has no base DNS zone")
+
+    domain = dns_models.Domain.objects.get_one_or_none(
+        filters={"name": dm_filters.EQ(domain_name)}
+    )
+    if domain is not None:
+        if not (
+            domain.realm_id == realm_id
+            and domain.sync_only
+            and domain.sync_to_ecosystem
+        ):
+            raise RuntimeError(
+                f"DNS domain {domain_name} already exists with another scope"
+            )
+        return True
+
+    dns_models.Domain(
+        name=domain_name,
+        realm_id=realm_id,
+        sync_only=True,
+        sync_to_ecosystem=True,
+        project_id=c.ZERO_UUID,
+    ).insert()
+    LOG.info("Created sync-only realm DNS domain %s", domain_name)
     return True
 
 

--- a/exordos_core/cmd/bootstrap.py
+++ b/exordos_core/cmd/bootstrap.py
@@ -691,6 +691,7 @@ def _set_defaults_vs(spec: dict[str, tp.Any]):
         {"func": bootstrap_defaults.set_disable_telemetry_var, "args": [spec]},
         {"func": bootstrap_defaults.set_realm_uuid_var, "args": [spec]},
         {"func": bootstrap_defaults.set_realm_secret_var, "args": [spec]},
+        {"func": bootstrap_defaults.ensure_realm_dns_domain, "args": [spec]},
         {"func": bootstrap_defaults.set_realm_access_token_var, "args": [spec]},
         {"func": bootstrap_defaults.set_realm_refresh_token_var, "args": [spec]},
         {

--- a/exordos_core/dns_sync/service.py
+++ b/exordos_core/dns_sync/service.py
@@ -38,7 +38,7 @@ FULL_SYNC_INTERVAL = 60
 
 
 class DNSSyncService(basic.BasicService):
-    """Periodically syncs local DNS records to the ecosystem."""
+    """Publishes realm-scoped logical DNS records through Ecosystem."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -46,11 +46,10 @@ class DNSSyncService(basic.BasicService):
         self._executor = futures.ThreadPoolExecutor(max_workers=DNS_SYNC_POOL_SIZE)
         self._pending_future = None
         self._initialized = False
-        self._last_full_sync_at = FULL_SYNC_INTERVAL + 1  # sync immediately on start
-        self._last_fast_sync_dt = None
+        self._last_full_sync_at = FULL_SYNC_INTERVAL + 1
+        self._last_sync_dt = None
 
     def _get_variable_value(self, var_uuid):
-        """Read variable value from ValuesStore by UUID."""
         variable = vs_models.Variable.objects.get_one_or_none(
             filters={"uuid": dm_filters.EQ(var_uuid)}
         )
@@ -59,132 +58,109 @@ class DNSSyncService(basic.BasicService):
         return variable.value
 
     def _get_ecosystem_credentials(self):
-        """Read ecosystem endpoint, stand UUID, secret and token from VS."""
         endpoint = self._get_variable_value(c.VAR_ECOSYSTEM_ENDPOINT_UUID)
         realm_uuid = self._get_variable_value(c.VAR_REALM_UUID_UUID)
         realm_secret = self._get_variable_value(c.VAR_REALM_SECRET_UUID)
-        access_token = self._get_variable_value(c.VAR_REALM_ACCESS_TOKEN_UUID)
-        if not all([endpoint, realm_uuid, realm_secret, access_token]):
+        if not all([endpoint, realm_uuid, realm_secret]):
             return None
-        return endpoint, realm_uuid, realm_secret, access_token
-
-    def _make_basic_auth(self, realm_uuid, realm_secret):
-        return requests_auth.HTTPBasicAuth(realm_uuid, realm_secret)
+        return endpoint, realm_uuid, realm_secret
 
     @staticmethod
-    def _bearer_headers(access_token):
-        return {
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json",
-        }
-
-    # ------------------------------------------------------------------
-    # Ecosystem HTTP helpers
-    # ------------------------------------------------------------------
+    def _make_basic_auth(realm_uuid, realm_secret):
+        return requests_auth.HTTPBasicAuth(realm_uuid, realm_secret)
 
     def _eco_get_realm(self, endpoint, realm_uuid, auth):
-        """GET /api/ecosystem/v1/realms/{realm_uuid} -> realm dict."""
         url = f"{endpoint}/api/ecosystem/v1/realms/{realm_uuid}"
-        resp = self._client.get(url, auth=auth)
-        return resp.json()
+        return self._client.get(url, auth=auth).json()
 
-    def _eco_list_domains(self, endpoint, headers):
-        """GET /api/core/v1/dns/domains/ -> list of domains."""
-        url = f"{endpoint}/api/core/v1/dns/domains/"
-        resp = self._client.get(url, headers=headers)
-        return resp.json()
-
-    def _eco_create_domain(self, endpoint, headers, name):
-        """POST /api/core/v1/dns/domains/"""
-        url = f"{endpoint}/api/core/v1/dns/domains/"
-        resp = self._client.post(
-            url,
-            json={"name": name},
-            headers=headers,
-        )
-        return resp.json()
-
-    def _eco_list_records(self, endpoint, headers, eco_domain_uuid):
-        """GET /api/core/v1/dns/domains/{uuid}/records/"""
-        url = f"{endpoint}/api/core/v1/dns/domains/{eco_domain_uuid}/records/"
-        resp = self._client.get(url, headers=headers)
-        return resp.json()
-
-    def _eco_create_record(self, endpoint, headers, eco_domain_uuid, record_data):
-        """POST /api/core/v1/dns/domains/{uuid}/records/"""
-        url = f"{endpoint}/api/core/v1/dns/domains/{eco_domain_uuid}/records/"
+    def _eco_sync_domain(self, endpoint, realm_uuid, auth, domain, records):
+        url = f"{endpoint}/api/ecosystem/v1/realms/{realm_uuid}/actions/sync_dns/invoke"
         self._client.post(
             url,
-            json=record_data,
-            headers=headers,
+            auth=auth,
+            json={
+                "domain": {
+                    "name": domain.name,
+                    "realm_id": domain.realm_id,
+                },
+                "records": records,
+            },
         )
 
-    def _eco_update_record(
-        self, endpoint, headers, eco_domain_uuid, record_uuid, record_data
-    ):
-        """PUT /api/core/v1/dns/domains/{uuid}/records/{rid}"""
-        url = (
-            f"{endpoint}/api/core/v1"
-            f"/dns/domains/{eco_domain_uuid}/records/{record_uuid}"
+    def _realm_domains(self):
+        domains = dns_models.Domain.objects.get_all(
+            filters={"sync_to_ecosystem": dm_filters.EQ(True)}
         )
-        self._client.put(
-            url,
-            json=record_data,
-            headers=headers,
-        )
+        return [domain for domain in domains if domain.realm_id is not None]
 
-    def _eco_delete_record(self, endpoint, headers, eco_domain_uuid, record_uuid):
-        """DELETE /api/core/v1/dns/domains/{uuid}/records/{rid}"""
-        url = (
-            f"{endpoint}/api/core/v1"
-            f"/dns/domains/{eco_domain_uuid}/records/{record_uuid}"
-        )
-        self._client.delete(url, headers=headers)
+    def _ensure_realm_domain(self, endpoint, realm_uuid, auth):
+        domains = self._realm_domains()
+        if domains:
+            return True
 
-    # ------------------------------------------------------------------
-    # Initialization: fetch realm domain, mark local domain for sync
-    # ------------------------------------------------------------------
-
-    def _ensure_realm_domain(self, endpoint, realm_uuid, basic_auth):
-        """Fetch realm domain from ecosystem and ensure it exists locally
-        with sync_to_ecosystem=True.
-        """
-        realm = self._eco_get_realm(endpoint, realm_uuid, basic_auth)
-        realm_domain_name = realm.get("domain")
-        if not realm_domain_name:
-            LOG.warning("Realm has no domain field, skipping init")
+        realm = self._eco_get_realm(endpoint, realm_uuid, auth)
+        realm_id = realm.get("realm_id")
+        realm_domain = (realm.get("domain") or "").lower().rstrip(".")
+        if not realm_id or not realm_domain:
+            LOG.warning("Realm has no realm_id/domain DNS contract")
             return False
 
-        LOG.info("Realm domain: %s", realm_domain_name)
+        prefix = f"{realm_id}."
+        if not realm_domain.startswith(prefix):
+            raise ValueError("Ecosystem realm domain does not match realm_id")
+        domain_name = realm_domain.removeprefix(prefix)
 
         domain = dns_models.Domain.objects.get_one_or_none(
-            filters={"name": dm_filters.EQ(realm_domain_name)}
+            filters={"name": dm_filters.EQ(domain_name)}
         )
         if domain is None:
-            LOG.info(
-                "Creating local domain %s for ecosystem sync",
-                realm_domain_name,
+            legacy_domain = dns_models.Domain.objects.get_one_or_none(
+                filters={"name": dm_filters.EQ(realm_domain)}
             )
+            if legacy_domain is not None:
+                if not (
+                    legacy_domain.realm_id is None
+                    and not legacy_domain.sync_only
+                    and legacy_domain.sync_to_ecosystem
+                ):
+                    raise ValueError(
+                        "Legacy local DNS domain conflicts with the realm DNS contract"
+                    )
+
+                legacy_domain.name = domain_name
+                legacy_domain.realm_id = realm_id
+                legacy_domain.sync_only = True
+                legacy_domain.update()
+                for record in dns_models.Record.objects.get_all(
+                    filters={"domain": dm_filters.EQ(legacy_domain)}
+                ):
+                    if record.type == "SOA":
+                        record.delete(force=True)
+                    else:
+                        record.update()
+                LOG.info("Migrated legacy realm DNS domain to %s", domain_name)
+                return True
+
             domain = dns_models.Domain(
-                name=realm_domain_name,
-                project_id=c.ZERO_UUID,
+                name=domain_name,
+                realm_id=realm_id,
+                sync_only=True,
                 sync_to_ecosystem=True,
+                project_id=c.ZERO_UUID,
             )
-            domain.save()
-        elif not domain.sync_to_ecosystem:
-            LOG.info("Marking domain %s for ecosystem sync", realm_domain_name)
-            domain.sync_to_ecosystem = True
-            domain.update()
+            domain.insert()
+            return True
 
+        if not (
+            domain.realm_id == realm_id
+            and domain.sync_only
+            and domain.sync_to_ecosystem
+        ):
+            raise ValueError("Local DNS domain conflicts with the realm DNS contract")
         return True
-
-    # ------------------------------------------------------------------
-    # Record sync logic
-    # ------------------------------------------------------------------
 
     @staticmethod
     def _build_record_data(record):
-        """Convert a local Record to the dict sent to ecosystem."""
         record_prop = record.properties.properties["record"]
         record_type = record_prop.get_property_type()
         return {
@@ -193,297 +169,90 @@ class DNSSyncService(basic.BasicService):
             "ttl": record.ttl,
             "disabled": record.disabled,
             "record": record_type.to_simple_type(record.record),
+            "full_name": record.full_name,
         }
 
-    # ------------------------------------------------------------------
-    # Fast path: push only new / updated records since last cycle
-    # ------------------------------------------------------------------
-
-    def _fast_sync(self, endpoint, headers, since_dt):
-        """Query all recently changed records, push them to ecosystem.
-
-        Records are selected globally by updated_at, then grouped by
-        domain.  Only domains with sync_to_ecosystem=True are processed.
-
-        New vs existing is determined by created_at: if the record was
-        created after since_dt it is new, otherwise it is an update.
-        This avoids fetching ecosystem records on each fast cycle.
-        """
-        recent_records = dns_models.Record.objects.get_all(
-            filters={
-                "updated_at": dm_filters.GE(since_dt),
-                "type": dm_filters.NE("SOA"),
-            }
-        )
-        if not recent_records:
-            return
-
-        # Group records by domain, keep only sync-enabled domains
-        by_domain = {}
-        for rec in recent_records:
-            domain = rec.domain
-            if not domain.sync_to_ecosystem:
-                continue
-            by_domain.setdefault(domain, []).append(rec)
-
-        if not by_domain:
-            return
-
-        # Fetch ecosystem domain list once for all domains
-        eco_domains = self._eco_list_domains(endpoint, headers)
-        eco_domain_map = {ed.get("name"): ed["uuid"] for ed in eco_domains}
-
-        for domain, records in by_domain.items():
-            eco_domain_uuid = eco_domain_map.get(domain.name)
-            if eco_domain_uuid is None:
-                LOG.debug(
-                    "Fast sync: domain %s not yet in ecosystem, "
-                    "skipping until full sync",
-                    domain.name,
-                )
-                continue
-
-            for rec in records:
-                data = self._build_record_data(rec)
-                try:
-                    if rec.created_at >= since_dt:
-                        LOG.debug(
-                            "Fast sync: creating record %s %s in %s",
-                            rec.type,
-                            rec.name,
-                            domain.name,
-                        )
-                        self._eco_create_record(
-                            endpoint,
-                            headers,
-                            eco_domain_uuid,
-                            data,
-                        )
-                    else:
-                        LOG.debug(
-                            "Fast sync: updating record %s %s in %s",
-                            rec.type,
-                            rec.name,
-                            domain.name,
-                        )
-                        self._eco_update_record(
-                            endpoint,
-                            headers,
-                            eco_domain_uuid,
-                            str(rec.uuid),
-                            data,
-                        )
-                except Exception:
-                    LOG.exception(
-                        "Fast sync: failed to push record %s %s",
-                        rec.type,
-                        rec.name,
-                    )
-
-    # ------------------------------------------------------------------
-    # Full reconciliation: build diff, create / delete
-    # ------------------------------------------------------------------
-
-    def _full_sync_domain(self, domain, endpoint, headers, eco_domain_uuid):
-        """Full diff-based sync for a single domain."""
-        domain_name = domain.name
-
-        # Get local records (skip SOA)
-        local_records = dns_models.Record.objects.get_all(
+    def _domain_records(self, domain):
+        records = dns_models.Record.objects.get_all(
             filters={
                 "domain": dm_filters.EQ(domain),
                 "type": dm_filters.NE("SOA"),
             }
         )
+        return [self._build_record_data(record) for record in records]
 
-        # Get ecosystem records
-        eco_records = self._eco_list_records(endpoint, headers, eco_domain_uuid)
-        eco_records = [r for r in eco_records if r.get("type") != "SOA"]
+    def _has_recent_changes(self, since_dt):
+        records = dns_models.Record.objects.get_all(
+            filters={
+                "updated_at": dm_filters.GE(since_dt),
+                "type": dm_filters.NE("SOA"),
+            }
+        )
+        return any(record.domain.realm_id is not None for record in records)
 
-        # Build UUID-keyed maps
-        local_map = {str(r.uuid): r for r in local_records}
-        eco_map = {r["uuid"]: r for r in eco_records if r.get("uuid")}
-
-        local_uuids = set(local_map.keys())
-        eco_uuids = set(eco_map.keys())
-
-        # Create missing
-        for uid in local_uuids - eco_uuids:
-            rec = local_map[uid]
-            LOG.info(
-                "Creating record %s %s in ecosystem domain %s",
-                rec.type,
-                rec.name,
-                domain_name,
-            )
-            try:
-                self._eco_create_record(
-                    endpoint,
-                    headers,
-                    eco_domain_uuid,
-                    self._build_record_data(rec),
-                )
-            except Exception:
-                LOG.exception(
-                    "Failed to create record %s %s in ecosystem",
-                    rec.type,
-                    rec.name,
-                )
-
-        # Update existing only if content differs
-        compare_keys = ("type", "ttl", "disabled", "record")
-        for uid in local_uuids & eco_uuids:
-            rec = local_map[uid]
-            local_data = self._build_record_data(rec)
-            eco_rec = eco_map[uid]
-            if all(local_data.get(k) == eco_rec.get(k) for k in compare_keys):
-                continue
-            try:
-                self._eco_update_record(
-                    endpoint,
-                    headers,
-                    eco_domain_uuid,
-                    uid,
-                    local_data,
-                )
-            except Exception:
-                LOG.exception(
-                    "Failed to update record %s %s in ecosystem",
-                    rec.type,
-                    rec.name,
-                )
-
-        # Delete extra
-        for uid in eco_uuids - local_uuids:
-            eco_rec = eco_map[uid]
-            LOG.info(
-                "Deleting record %s %s from ecosystem domain %s",
-                eco_rec.get("type"),
-                eco_rec.get("name"),
-                domain_name,
-            )
-            try:
-                self._eco_delete_record(
-                    endpoint,
-                    headers,
-                    eco_domain_uuid,
-                    uid,
-                )
-            except Exception:
-                LOG.exception(
-                    "Failed to delete record %s %s from ecosystem",
-                    eco_rec.get("type"),
-                    eco_rec.get("name"),
-                )
-
-    # ------------------------------------------------------------------
-    # Orchestration: decide fast path vs full reconciliation
-    # ------------------------------------------------------------------
-
-    def _sync_all_domains(self, endpoint, realm_uuid, realm_secret, access_token):
-        """Sync all local domains marked for ecosystem sync."""
-        basic_auth = self._make_basic_auth(realm_uuid, realm_secret)
-        headers = self._bearer_headers(access_token)
-
-        # Initialize on first successful call
+    def _sync_all_domains(self, endpoint, realm_uuid, realm_secret):
+        auth = self._make_basic_auth(realm_uuid, realm_secret)
         if not self._initialized:
             try:
-                initialized = self._ensure_realm_domain(
-                    endpoint, realm_uuid, basic_auth
-                )
+                initialized = self._ensure_realm_domain(endpoint, realm_uuid, auth)
             except bazooka_exc.ForbiddenError:
-                LOG.warning("Not authorized to fetch realm, skipping")
+                LOG.warning("Not authorized to fetch realm, skipping DNS sync")
                 return
-            except Exception:
-                LOG.exception("Failed to initialize realm domain")
-                return
-
             if not initialized:
                 return
             self._initialized = True
 
         now = time.monotonic()
         need_full = (now - self._last_full_sync_at) >= FULL_SYNC_INTERVAL
+        if (
+            not need_full
+            and self._last_sync_dt is not None
+            and not self._has_recent_changes(self._last_sync_dt)
+        ):
+            return
+
+        domains = self._realm_domains()
+        for domain in domains:
+            records = self._domain_records(domain)
+            try:
+                self._eco_sync_domain(
+                    endpoint,
+                    realm_uuid,
+                    auth,
+                    domain,
+                    records,
+                )
+            except Exception:
+                LOG.exception("DNS sync failed for realm domain %s", domain.name)
 
         if need_full:
-            domains = dns_models.Domain.objects.get_all(
-                filters={"sync_to_ecosystem": dm_filters.EQ(True)}
-            )
-            if not domains:
-                LOG.debug("No domains marked for ecosystem sync")
-                return
-
-            LOG.debug("Running full DNS reconciliation")
-            eco_domains = self._eco_list_domains(endpoint, headers)
-            eco_domain_map = {ed.get("name"): ed["uuid"] for ed in eco_domains}
-
-            for domain in domains:
-                try:
-                    eco_domain_uuid = eco_domain_map.get(domain.name)
-                    if eco_domain_uuid is None:
-                        LOG.info(
-                            "Creating domain %s in ecosystem",
-                            domain.name,
-                        )
-                        eco_domain = self._eco_create_domain(
-                            endpoint, headers, domain.name
-                        )
-                        eco_domain_uuid = eco_domain["uuid"]
-
-                    self._full_sync_domain(
-                        domain,
-                        endpoint,
-                        headers,
-                        eco_domain_uuid,
-                    )
-                except Exception:
-                    LOG.exception("Full sync failed for domain %s", domain.name)
             self._last_full_sync_at = now
-            self._last_fast_sync_dt = datetime.datetime.now(datetime.timezone.utc)
-        else:
-            since_dt = self._last_fast_sync_dt
-            if since_dt is None:
-                return
-            LOG.debug("Running fast DNS sync (since %s)", since_dt)
-            self._fast_sync(endpoint, headers, since_dt)
-            self._last_fast_sync_dt = datetime.datetime.now(datetime.timezone.utc)
-
-    # ------------------------------------------------------------------
-    # Service loop
-    # ------------------------------------------------------------------
+        self._last_sync_dt = datetime.datetime.now(datetime.timezone.utc)
 
     def _check_pending_future(self):
-        """Clear completed future to allow the next submission."""
         if self._pending_future is not None and self._pending_future.done():
             self._pending_future = None
 
     def _iteration(self):
         self._check_pending_future()
-
         if self._pending_future is not None:
             LOG.debug("Previous DNS sync request still pending, skipping")
             return
 
         with contexts.Context().session_manager():
-            creds = self._get_ecosystem_credentials()
-            if creds is None:
+            credentials = self._get_ecosystem_credentials()
+            if credentials is None:
                 LOG.debug("DNS sync variables are not configured, skipping")
                 return
 
-            endpoint, realm_uuid, realm_secret, access_token = creds
-
         self._pending_future = self._executor.submit(
             self._do_sync,
-            endpoint,
-            realm_uuid,
-            realm_secret,
-            access_token,
+            *credentials,
         )
 
-    def _do_sync(self, endpoint, realm_uuid, realm_secret, access_token):
-        """Run the full sync inside a DB session (executed in thread)."""
+    def _do_sync(self, endpoint, realm_uuid, realm_secret):
         try:
             with contexts.Context().session_manager():
-                self._sync_all_domains(endpoint, realm_uuid, realm_secret, access_token)
+                self._sync_all_domains(endpoint, realm_uuid, realm_secret)
         except Exception:
             LOG.exception("DNS sync iteration failed")

--- a/exordos_core/tests/functional/service/dns/test_pdns.py
+++ b/exordos_core/tests/functional/service/dns/test_pdns.py
@@ -19,9 +19,11 @@ import uuid as sys_uuid
 
 import dns.resolver
 from gcl_iam.tests.functional import clients as iam_clients
+import netaddr
 import pytest
 
 from exordos_core.common import constants as c
+from exordos_core.user_api.dns.dm import models as dns_models
 
 DEF_DOMAIN = "core.internal"
 
@@ -149,6 +151,8 @@ class TestDnsApi:
 
         assert response.status_code == 201
         assert self._cmp_shallow(data, output)
+        assert output["record"]["name"] == "test"
+        assert output["full_name"] == f"test.{DEF_DOMAIN}"
 
         url = client.build_resource_uri(
             ["dns", "domains", domain1["uuid"], "records", data["uuid"]]
@@ -170,6 +174,39 @@ class TestDnsApi:
         response = client.delete(url)
 
         assert response.status_code == 204
+
+    @pytest.mark.xdist_group(name="pdns")
+    def test_sync_only_realm_domain_is_hidden_from_powerdns_views(self, user_api):
+        domain = dns_models.Domain(
+            name="example.com",
+            realm_id="a5f3957",
+            sync_only=True,
+            sync_to_ecosystem=True,
+            project_id=c.ZERO_UUID,
+        )
+        domain.insert()
+        record = dns_models.Record(
+            domain=domain,
+            type="A",
+            record=dns_models.ARecord(
+                name="workspace",
+                address=netaddr.IPAddress("192.0.2.10"),
+            ),
+            project_id=c.ZERO_UUID,
+        )
+        record.insert()
+
+        with domain._get_engine().session_manager() as session:
+            domains = session.execute(
+                "SELECT name FROM domains WHERE name = %s", (domain.name,)
+            ).fetchall()
+            records = session.execute(
+                "SELECT name FROM records WHERE domain_id = %s", (domain.id,)
+            ).fetchall()
+
+        assert domains == []
+        assert records == []
+        domain.delete()
 
     @pytest.mark.xdist_group(name="pdns")
     def test_txt_record(

--- a/exordos_core/tests/unit/cmd/test_bootstrap_realm_dns.py
+++ b/exordos_core/tests/unit/cmd/test_bootstrap_realm_dns.py
@@ -1,0 +1,75 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest import mock
+
+import pytest
+
+from exordos_core.bootstrap import defaults
+from exordos_core.common import constants as c
+
+
+def test_bootstrap_creates_sync_only_domain_from_realm_spec():
+    with mock.patch.object(defaults.dns_models, "Domain") as domain_model:
+        domain_model.objects.get_one_or_none.return_value = None
+
+        assert defaults.ensure_realm_dns_domain(
+            {
+                "realm_id": "a5f3957",
+                "realm_domain": "a5f3957.exordos.io",
+            }
+        )
+
+    domain_model.assert_called_once_with(
+        name="exordos.io",
+        realm_id="a5f3957",
+        sync_only=True,
+        sync_to_ecosystem=True,
+        project_id=c.ZERO_UUID,
+    )
+    domain_model.return_value.insert.assert_called_once_with()
+
+
+def test_bootstrap_accepts_matching_existing_domain():
+    existing = mock.Mock(
+        realm_id="a5f3957",
+        sync_only=True,
+        sync_to_ecosystem=True,
+    )
+    with mock.patch.object(defaults.dns_models, "Domain") as domain_model:
+        domain_model.objects.get_one_or_none.return_value = existing
+
+        assert defaults.ensure_realm_dns_domain(
+            {
+                "realm_id": "a5f3957",
+                "realm_domain": "a5f3957.exordos.io",
+            }
+        )
+
+    domain_model.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"realm_id": "a5f3957"},
+        {"realm_domain": "a5f3957.exordos.io"},
+        {"realm_id": "a5f3957", "realm_domain": "other.exordos.io"},
+    ],
+)
+def test_bootstrap_rejects_incomplete_or_mismatched_realm_dns(spec):
+    with pytest.raises(RuntimeError):
+        defaults.ensure_realm_dns_domain(spec)

--- a/exordos_core/tests/unit/dns/__init__.py
+++ b/exordos_core/tests/unit/dns/__init__.py
@@ -1,0 +1,4 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License.

--- a/exordos_core/tests/unit/dns/test_models.py
+++ b/exordos_core/tests/unit/dns/test_models.py
@@ -1,0 +1,104 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import uuid as sys_uuid
+
+import netaddr
+import pytest
+
+from exordos_core.common import constants as c
+from exordos_core.user_api.dns.dm import models
+
+REALM_ID = "a5f3957"
+
+
+def _domain(**kwargs):
+    values = {
+        "id": 1,
+        "name": "exordos.io",
+        "realm_id": REALM_ID,
+        "sync_only": True,
+        "sync_to_ecosystem": True,
+        "project_id": c.ZERO_UUID,
+    }
+    values.update(kwargs)
+    return models.Domain.restore(**values)
+
+
+def _a_record(domain, name="workspace"):
+    return models.Record(
+        uuid=sys_uuid.uuid4(),
+        domain=domain,
+        type="A",
+        record=models.ARecord(
+            name=name,
+            address=netaddr.IPAddress("192.0.2.10"),
+        ),
+        project_id=c.ZERO_UUID,
+    )
+
+
+def test_realm_record_keeps_logical_name_and_exposes_full_name():
+    record = _a_record(_domain())
+
+    assert record.record.name == "workspace"
+    assert record.full_name == "workspace-a5f3957.exordos.io"
+
+
+@pytest.mark.parametrize("name", ["", "@"])
+def test_realm_apex_uses_realm_id_as_owner(name):
+    record = _a_record(_domain(), name=name)
+
+    assert record.full_name == "a5f3957.exordos.io"
+
+
+def test_realm_full_name_is_canonical_lowercase_without_changing_logical_name():
+    record = _a_record(_domain(), name="Workspace")
+
+    assert record.record.name == "Workspace"
+    assert record.full_name == "workspace-a5f3957.exordos.io"
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        models.TXTRecord(name="verification", content="token"),
+        models.NSRecord(name="delegation", content="ns.example.com."),
+    ],
+)
+def test_realm_scope_applies_to_supported_owner_names(record):
+    assert record.get_name(_domain()) == (f"{record.name}-{REALM_ID}.exordos.io")
+
+
+@pytest.mark.parametrize("name", ["*.workspace", "api.workspace"])
+def test_realm_scope_rejects_names_that_cannot_stay_flat(name):
+    with pytest.raises(models.RealmRecordNameNotSupported):
+        _a_record(_domain(), name=name)
+
+
+def test_regular_domain_naming_is_unchanged():
+    domain = _domain(
+        name="example.com",
+        realm_id=None,
+        sync_only=False,
+        sync_to_ecosystem=False,
+    )
+
+    assert _a_record(domain).full_name == "workspace.example.com"
+
+
+def test_soa_remains_at_the_physical_zone_apex():
+    assert models.SOARecord(name="").get_name(_domain()) == "exordos.io"

--- a/exordos_core/tests/unit/dns/test_sync_service.py
+++ b/exordos_core/tests/unit/dns/test_sync_service.py
@@ -1,0 +1,107 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from exordos_core.common import constants as c
+from exordos_core.dns_sync import service as dns_sync
+
+
+@pytest.fixture
+def service():
+    instance = dns_sync.DNSSyncService()
+    yield instance
+    instance._executor.shutdown(wait=False)
+
+
+def test_sync_uses_realm_authenticated_ecosystem_action(service):
+    service._client = mock.Mock()
+    domain = SimpleNamespace(name="exordos.io", realm_id="a5f3957")
+    auth = mock.sentinel.auth
+    records = [{"uuid": "record", "full_name": "workspace-a5f3957.exordos.io"}]
+
+    service._eco_sync_domain(
+        "https://ecosystem.example.com",
+        "realm-uuid",
+        auth,
+        domain,
+        records,
+    )
+
+    service._client.post.assert_called_once_with(
+        "https://ecosystem.example.com/api/ecosystem/v1/realms/realm-uuid"
+        "/actions/sync_dns/invoke",
+        auth=auth,
+        json={
+            "domain": {"name": "exordos.io", "realm_id": "a5f3957"},
+            "records": records,
+        },
+    )
+
+
+def test_dns_sync_does_not_require_shared_project_access_token(service):
+    values = {
+        c.VAR_ECOSYSTEM_ENDPOINT_UUID: "https://ecosystem.example.com",
+        c.VAR_REALM_UUID_UUID: "realm-uuid",
+        c.VAR_REALM_SECRET_UUID: "realm-secret",
+    }
+    service._get_variable_value = values.get
+
+    assert service._get_ecosystem_credentials() == (
+        "https://ecosystem.example.com",
+        "realm-uuid",
+        "realm-secret",
+    )
+
+
+def test_initialization_migrates_the_legacy_realm_domain(service):
+    legacy_domain = mock.Mock(
+        realm_id=None,
+        sync_only=False,
+        sync_to_ecosystem=True,
+    )
+    soa = mock.Mock(type="SOA")
+    record = mock.Mock(type="A")
+    service._realm_domains = mock.Mock(return_value=[])
+    service._eco_get_realm = mock.Mock(
+        return_value={
+            "realm_id": "a5f3957",
+            "domain": "a5f3957.exordos.io",
+        }
+    )
+
+    with (
+        mock.patch.object(dns_sync.dns_models, "Domain") as domain_model,
+        mock.patch.object(dns_sync.dns_models, "Record") as record_model,
+    ):
+        domain_model.objects.get_one_or_none.side_effect = [None, legacy_domain]
+        record_model.objects.get_all.return_value = [soa, record]
+
+        assert service._ensure_realm_domain(
+            "https://ecosystem.example.com",
+            "realm-uuid",
+            mock.sentinel.auth,
+        )
+
+    assert legacy_domain.name == "exordos.io"
+    assert legacy_domain.realm_id == "a5f3957"
+    assert legacy_domain.sync_only is True
+    legacy_domain.update.assert_called_once_with()
+    soa.delete.assert_called_once_with(force=True)
+    record.update.assert_called_once_with()

--- a/exordos_core/user_api/dns/api/controllers.py
+++ b/exordos_core/user_api/dns/api/controllers.py
@@ -44,6 +44,8 @@ class DomainController(
             default=field_p.Permissions.RW,
             fields={
                 "id": {constants.ALL: field_p.Permissions.HIDDEN},
+                "realm_id": {constants.ALL: field_p.Permissions.RO},
+                "sync_only": {constants.ALL: field_p.Permissions.RO},
             },
         ),
     )
@@ -57,13 +59,14 @@ class RecordController(
     __policy_service_name__ = "dns"
     __policy_name__ = "record"
 
-    __resource__ = resources.ResourceByRAModel(
+    __resource__ = resources.ResourceByModelWithCustomProps(
         models.Record,
         convert_underscore=False,
         fields_permissions=field_p.FieldsPermissions(
             default=field_p.Permissions.RW,
             fields={
                 "domain_id": {constants.ALL: field_p.Permissions.HIDDEN},
+                "full_name": {constants.ALL: field_p.Permissions.RO},
                 "name": {constants.ALL: field_p.Permissions.RO},
                 "content": {constants.ALL: field_p.Permissions.HIDDEN},
             },

--- a/exordos_core/user_api/dns/dm/models.py
+++ b/exordos_core/user_api/dns/dm/models.py
@@ -38,6 +38,11 @@ class SOARecordDeleteRestricted(exceptions.RestAlchemyException):
     message = "SOA record cannot be deleted without domain deletion."
 
 
+class RealmRecordNameNotSupported(exceptions.RestAlchemyException):
+    code = 400
+    message = "Realm-scoped record name is not supported: %(reason)s"
+
+
 class CommonModel(
     models.ModelWithTimestamp,
     models.ModelWithUUID,
@@ -51,6 +56,11 @@ class Domain(CommonModel, models.ModelWithProject, ua_models.TargetResourceMixin
     __tablename__ = "dns_domains"
     name = properties.property(types.String(), required=True)
     sync_to_ecosystem = properties.property(types.Boolean(), default=False)
+    sync_only = properties.property(types.Boolean(), default=False)
+    realm_id = properties.property(
+        types.AllowNone(types.BaseCompiledRegExpType(re.compile(r"^[0-9a-f]{6,32}$"))),
+        default=None,
+    )
     # Used only for PDNS
     id = properties.property(types.Integer())
     # Next columns exist in DB but used only for PDNS support and have
@@ -74,12 +84,55 @@ class Domain(CommonModel, models.ModelWithProject, ua_models.TargetResourceMixin
     def __init__(self, session=None, **kwargs):
         super().__init__(id=self.get_next_domain_id(session=session), **kwargs)
 
+    def validate(self):
+        if self.realm_id is None and self.sync_only:
+            raise ValueError("sync-only DNS domains require realm_id")
+        if self.realm_id is not None and not (
+            self.sync_only and self.sync_to_ecosystem
+        ):
+            raise ValueError(
+                "realm-scoped DNS domains must be sync-only and sync to ecosystem"
+            )
+
+    def get_record_name(self, record_name: str) -> str:
+        if self.realm_id is None:
+            return ".".join((record_name, self.name)) if record_name else self.name
+
+        normalized_name = "" if record_name == "@" else record_name.lower()
+        if "*" in normalized_name:
+            raise RealmRecordNameNotSupported(
+                reason="wildcards cannot express a realm-specific flat suffix"
+            )
+        if "." in normalized_name:
+            raise RealmRecordNameNotSupported(
+                reason="nested owner names are not covered by the flat realm namespace"
+            )
+
+        relative_name = (
+            self.realm_id
+            if not normalized_name
+            else f"{normalized_name}-{self.realm_id}"
+        )
+        if len(relative_name) > 63:
+            raise RealmRecordNameNotSupported(
+                reason="the materialized DNS label exceeds 63 characters"
+            )
+
+        full_name = f"{relative_name}.{self.name}"
+        if len(full_name) > 253:
+            raise RealmRecordNameNotSupported(
+                reason="the materialized DNS name exceeds 253 characters"
+            )
+        return full_name
+
     def insert(self, session=None):
         # TODO: to be public autoritative DNS, we need:
         #  - make sure the SOA record is correct (serial, too, for zone transfers)
         #    (or don't update serial, it's needed only for secondary DNS replicaion,
         #     we can just don't support it, route53 doesn't support it either)
         super().insert(session=session)
+        if self.sync_only:
+            return
         # TODO: make default soa record configurable
         # TODO: set soa serial as date, see ya.ru for example
         soa = Record(
@@ -107,7 +160,7 @@ class Domain(CommonModel, models.ModelWithProject, ua_models.TargetResourceMixin
 
 class AbstractRecord(types_dynamic.AbstractKindModel):
     def get_name(self, domain) -> str:
-        return (".").join((self.name, domain.name)) if self.name else domain.name
+        return domain.get_record_name(self.name)
 
     def get_content(self, domain) -> str:
         return str(self.content)
@@ -146,6 +199,9 @@ class SOARecord(AbstractRecord):
     expire = properties.property(types.Integer(min_value=60), default=604800)
     ttl = properties.property(types.Integer(min_value=60), default=3600)
 
+    def get_name(self, domain) -> str:
+        return domain.name
+
     def get_content(self, domain) -> str:
         return f"{self.primary_dns} {domain.name} {self.serial} {self.refresh} {self.retry} {self.expire} {self.ttl}"
 
@@ -177,8 +233,14 @@ class NSRecord(AbstractRecord):
     )
 
 
-class Record(CommonModel, models.ModelWithProject, ua_models.TargetResourceMixin):
+class Record(
+    CommonModel,
+    models.ModelWithProject,
+    models.CustomPropertiesMixin,
+    ua_models.TargetResourceMixin,
+):
     __tablename__ = "dns_records"
+    __custom_properties__ = {"full_name": types.String()}
     domain = relationships.relationship(Domain, required=True)
     domain_id = properties.property(types.Integer())
     type = properties.property(
@@ -211,6 +273,10 @@ class Record(CommonModel, models.ModelWithProject, ua_models.TargetResourceMixin
         super().__init__(domain=domain, domain_id=domain.id, **kwargs)
 
         self._fill_n_validate_record()
+
+    @property
+    def full_name(self) -> str:
+        return self.name
 
     def _fill_n_validate_record(self) -> None:
         if self.type != self.record.kind:

--- a/migrations/0002-realm-scoped-dns-5bd99b.py
+++ b/migrations/0002-realm-scoped-dns-5bd99b.py
@@ -1,0 +1,109 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+DOMAINS_VIEW = """
+CREATE OR REPLACE VIEW public.domains AS
+SELECT id, name, master, last_check, type, notified_serial, account, options, catalog
+FROM public.dns_domains
+WHERE NOT sync_only
+"""
+
+RECORDS_VIEW = """
+CREATE OR REPLACE VIEW public.records AS
+SELECT records.domain_id,
+       records.name,
+       records.type,
+       records.content,
+       records.ttl,
+       records.prio,
+       records.disabled,
+       records.ordername,
+       records.auth
+FROM public.dns_records records
+JOIN public.dns_domains domains ON domains.id = records.domain_id
+WHERE NOT domains.sync_only
+"""
+
+LEGACY_DOMAINS_VIEW = """
+CREATE OR REPLACE VIEW public.domains AS
+SELECT id, name, master, last_check, type, notified_serial, account, options, catalog
+FROM public.dns_domains
+"""
+
+LEGACY_RECORDS_VIEW = """
+CREATE OR REPLACE VIEW public.records AS
+SELECT domain_id, name, type, content, ttl, prio, disabled, ordername, auth
+FROM public.dns_records
+"""
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+    def __init__(self):
+        self._depends = ["0002-add-repo-element-version-flags-24310b.py"]
+
+    @property
+    def migration_id(self):
+        return "5bd99bee-1705-4329-ae88-0848f85b9546"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        session.execute(
+            "ALTER TABLE public.dns_domains "
+            "ADD COLUMN sync_only boolean DEFAULT false NOT NULL"
+        )
+        session.execute(
+            "ALTER TABLE public.dns_domains ADD COLUMN realm_id character varying(32)"
+        )
+        session.execute(
+            "ALTER TABLE public.dns_domains ADD CONSTRAINT "
+            "dns_domains_realm_id_format_check CHECK "
+            "(realm_id IS NULL OR realm_id ~ '^[0-9a-f]{6,32}$')"
+        )
+        session.execute(
+            "ALTER TABLE public.dns_domains ADD CONSTRAINT "
+            "dns_domains_realm_scope_check CHECK "
+            "((realm_id IS NULL AND NOT sync_only) OR "
+            "(realm_id IS NOT NULL AND sync_only AND sync_to_ecosystem))"
+        )
+        session.execute(
+            "CREATE UNIQUE INDEX dns_domains_realm_id_idx "
+            "ON public.dns_domains (realm_id) WHERE realm_id IS NOT NULL"
+        )
+        session.execute(DOMAINS_VIEW)
+        session.execute(RECORDS_VIEW)
+
+    def downgrade(self, session):
+        session.execute(LEGACY_DOMAINS_VIEW)
+        session.execute(LEGACY_RECORDS_VIEW)
+        session.execute("DROP INDEX public.dns_domains_realm_id_idx")
+        session.execute(
+            "ALTER TABLE public.dns_domains "
+            "DROP CONSTRAINT dns_domains_realm_scope_check"
+        )
+        session.execute(
+            "ALTER TABLE public.dns_domains "
+            "DROP CONSTRAINT dns_domains_realm_id_format_check"
+        )
+        session.execute("ALTER TABLE public.dns_domains DROP COLUMN realm_id")
+        session.execute("ALTER TABLE public.dns_domains DROP COLUMN sync_only")
+
+
+migration_step = MigrationStep()


### PR DESCRIPTION
## Summary

- add read-only `realm_id` and `sync_only` domain metadata and a separate read-only `full_name` record field
- keep `record.name` as the logical client value while materializing flat realm-scoped owner names internally
- create the sync-only logical base domain from the Ecosystem bootstrap specification
- publish complete realm DNS state through the realm-authenticated Ecosystem action instead of direct shared-project DNS access
- exclude sync-only domains from PowerDNS SQL views and migrate legacy local realm zones on first sync

## API contract

For a realm ID `a5f3957` in `exordos.io`, logical record name `workspace` remains `workspace` in the nested record object and `full_name` is `workspace-a5f3957.exordos.io`. Apex names materialize as `a5f3957.exordos.io`. Wildcard and nested logical owners are rejected because they cannot be represented safely in the flat wildcard-covered namespace.

## Validation

- `tox -e ruff-check`
- `tox -e py314` — 277 passed
- `tox -e openapi_artifacts`
- targeted DNS functional suite — 2 passed, 3 skipped because the optional PowerDNS binary was unavailable
- migration applied successfully to a clean PostgreSQL database; sync-only domains and records were verified absent from the PowerDNS SQL views

## Related

- Tracking issue: #574
- Companion Ecosystem PR: exordos/exordos_ecosystem#77

## Summary by Sourcery

Add realm-scoped sync-only DNS support with safe record-name materialization and authenticated Ecosystem publication.

New Features:
- Expose realm scope and sync-only status for DNS domains and provide read-only materialized record names while preserving logical record names.
- Bootstrap each realm’s sync-only DNS base domain from its realm specification.
- Publish realm DNS state through a realm-authenticated Ecosystem synchronization action.

Bug Fixes:
- Prevent sync-only realm domains and records from appearing in PowerDNS SQL views.
- Migrate compatible legacy local realm zones during initial synchronization.

Enhancements:
- Enforce valid realm-scoped DNS naming and domain configuration, including restrictions on wildcards and nested owners.

Tests:
- Add unit and functional coverage for realm DNS naming, bootstrap behavior, synchronization authorization, legacy migration, and PowerDNS view isolation.