### PR TITLE
add secret permissions to core manifest

### DIFF
--- a/exordos/manifests/core.yaml.j2
+++ b/exordos/manifests/core.yaml.j2
@@ -426,6 +426,70 @@ resources:
       uuid: "f4e3fc03-383c-5569-a65e-5f04ea05e3c8"
       name: "network.lb_vhost_route.update"
       description: "Update LB vhost routes"
+    secret_certificate_create:
+      uuid: "28c3d63c-b331-42dc-86b5-5cb79bd467e0"
+      name: "secret.certificate.create"
+      description: "Create certificates"
+    secret_certificate_delete:
+      uuid: "73d511a6-5d31-4d83-af0a-3227076eabe0"
+      name: "secret.certificate.delete"
+      description: "Delete certificates"
+    secret_certificate_read:
+      uuid: "9fbcf344-550b-4069-a6b1-adcab6bfe403"
+      name: "secret.certificate.read"
+      description: "List and read certificates"
+    secret_certificate_update:
+      uuid: "296eca3a-a17f-4071-8f02-f672943da3e1"
+      name: "secret.certificate.update"
+      description: "Update certificates"
+    secret_password_create:
+      uuid: "b2f5e33a-77bf-41d7-a34e-61140f2b4f48"
+      name: "secret.password.create"
+      description: "Create passwords"
+    secret_password_delete:
+      uuid: "830d20d1-c744-44dc-b1bb-f23add9a2c0c"
+      name: "secret.password.delete"
+      description: "Delete passwords"
+    secret_password_read:
+      uuid: "988f4081-a398-4ffb-a07f-efdcf28d77ff"
+      name: "secret.password.read"
+      description: "List and read passwords"
+    secret_password_update:
+      uuid: "95e58a5a-80c1-4c16-8c4b-b7105697b182"
+      name: "secret.password.update"
+      description: "Update passwords"
+    secret_rsa_key_create:
+      uuid: "de83aee9-d972-4f22-8854-b225e2a8860c"
+      name: "secret.rsa_key.create"
+      description: "Create RSA keys"
+    secret_rsa_key_delete:
+      uuid: "a6349cdf-6f1e-4ff8-a57a-c56cd39091c6"
+      name: "secret.rsa_key.delete"
+      description: "Delete RSA keys"
+    secret_rsa_key_read:
+      uuid: "1876e7de-dc35-4dce-bf5e-292158a6b6c6"
+      name: "secret.rsa_key.read"
+      description: "List and read RSA keys"
+    secret_rsa_key_update:
+      uuid: "4d1a99a4-a4a3-4d95-8c9a-03d94d1d2e77"
+      name: "secret.rsa_key.update"
+      description: "Update RSA keys"
+    secret_ssh_key_create:
+      uuid: "e491736f-2749-42f7-ad39-bea4362cc38e"
+      name: "secret.ssh_key.create"
+      description: "Create SSH keys"
+    secret_ssh_key_delete:
+      uuid: "23102ef6-c168-4490-8cd1-4b1a6903964b"
+      name: "secret.ssh_key.delete"
+      description: "Delete SSH keys"
+    secret_ssh_key_read:
+      uuid: "42079bc1-48b3-4ffd-8131-35d1e4e5be05"
+      name: "secret.ssh_key.read"
+      description: "List and read SSH keys"
+    secret_ssh_key_update:
+      uuid: "de7298aa-45d0-442f-96a2-efc84a40c56d"
+      name: "secret.ssh_key.update"
+      description: "Update SSH keys"
 
   $core.iam.rolebinding:
     admin_role:


### PR DESCRIPTION
## Summary by Sourcery

Add IAM permissions for managing various secret types in the core manifest.

New Features:
- Define create, read, update, and delete permissions for certificate secrets in the core manifest.
- Define create, read, update, and delete permissions for password secrets in the core manifest.
- Define create, read, update, and delete permissions for RSA key secrets in the core manifest.
- Define create, read, update, and delete permissions for SSH key secrets in the core manifest.