### PR TITLE
Fixes before SDN

### DIFF
--- a/docs/em/manifest.md
+++ b/docs/em/manifest.md
@@ -84,7 +84,7 @@ resources:
       group: "ubuntu"
       target:
         kind: "node"
-        node: "$my_app.compute.nodes.$app_node:uuid"
+        node: "$core.compute.nodes.$app_node:uuid"
       service_type:
         kind: "simple"
         count: 1

--- a/docs/em/manifest.ru.md
+++ b/docs/em/manifest.ru.md
@@ -84,7 +84,7 @@ resources:
       group: "ubuntu"
       target:
         kind: "node"
-        node: "$my_app.compute.nodes.$app_node:uuid"
+        node: "$core.compute.nodes.$app_node:uuid"
       service_type:
         kind: "simple"
         count: 1

--- a/exordos/exordos.yaml
+++ b/exordos/exordos.yaml
@@ -16,6 +16,11 @@ build:
         - build
         - cover
         - output
+        # Agent scaffolding, and git worktrees are kept under it -- whole
+        # checkouts with virtualenvs of their own, which the names above do
+        # not reach because they only match at the top level. A build that
+        # meets one fills the provisioning disk and dies in the upload.
+        - .claude
 
     # Binary artifacts. Kernel, initrd, boot loaders.
     - dst: /opt/exordos_core/artifacts/undionly.kpxe

--- a/exordos_core/network/border/builders/paas.py
+++ b/exordos_core/network/border/builders/paas.py
@@ -69,7 +69,6 @@ class BorderBuilder(builder.PaaSBuilder):
                     agent_uuid=instance.node,
                     snat_rules=instance.get_snat_rules(),
                     forwards=instance.get_forwards(),
-                    routes=instance.get_routes(),
                 )
             ]
         elif instance.type.kind == "core":
@@ -81,7 +80,6 @@ class BorderBuilder(builder.PaaSBuilder):
                     agent_uuid=sys_uuid.UUID(node_uuid),
                     snat_rules=instance.get_snat_rules(),
                     forwards=instance.get_forwards(),
-                    routes=instance.get_routes(),
                 )
                 for node_uuid in self._get_iaas_nodes(instance)
             ]
@@ -91,7 +89,6 @@ class BorderBuilder(builder.PaaSBuilder):
                     uuid=instance.uuid,
                     snat_rules=instance.get_snat_rules(),
                     forwards=instance.get_forwards(),
-                    routes=instance.get_routes(),
                 )
             ]
 

--- a/exordos_core/network/border/dm/models.py
+++ b/exordos_core/network/border/dm/models.py
@@ -30,6 +30,14 @@ class BorderAgent(
     """Border capability applied on the core node's agent (step 0).
 
     Carries the NAT / forward rules the DP agent renders into nftables.
+
+    There was a `routes` here too, sent empty by everything that built one
+    and read by nothing — it would have been the hook for reaching a realm
+    across a router, which is not the way this went: the hypervisors share
+    a segment with the load balancer, so the address is attracted by ARP
+    and there is no route for anyone to hold. The data plane dropped it
+    first, and what a field costs when only one side drops it is the whole
+    capability. If the routed variant arrives, this comes back with it.
     """
 
     status = properties.property(
@@ -38,7 +46,6 @@ class BorderAgent(
     )
     snat_rules = properties.property(types.List(), default=lambda: [])
     forwards = properties.property(types.List(), default=lambda: [])
-    routes = properties.property(types.List(), default=lambda: [])
 
     @classmethod
     def get_resource_kind(cls) -> str:
@@ -50,7 +57,6 @@ class BorderAgent(
                 "uuid",
                 "snat_rules",
                 "forwards",
-                "routes",
             )
         )
 
@@ -120,7 +126,3 @@ class PaasBorder(models.Border, ua_models.InstanceWithDerivativesMixin):
 
     def get_forwards(self):
         return self.forwards or []
-
-    def get_routes(self):
-        # Reserved for explicit static routes the border must install.
-        return []

--- a/exordos_core/network/dhcp/isc.py
+++ b/exordos_core/network/dhcp/isc.py
@@ -93,7 +93,7 @@ _host_template = """
 
 _subnet_template = """
 subnet {net_address} netmask {net_mask} {{
-	option domain-name-servers {dns_servers};
+	{dns_servers}
 	{routers}
 	{pool}
 	{hosts}
@@ -155,7 +155,16 @@ def dhcp_config(subnets: tp.Dict[models.Subnet, tp.List[models.Port]]) -> str:
         else:
             netboot = ""
 
-        dns_servers = ",".join(subnet.dns_servers)
+        # An option with no value is a syntax error, and dhcpd refuses the
+        # whole file over one: a subnet that names no resolver — a pool of
+        # addresses nothing is placed in, for instance — took the PXE server
+        # down for every network on the host, and the only sign of it was
+        # guests looping on "No configuration methods succeeded".
+        dns_servers = (
+            "option domain-name-servers %s;" % ",".join(subnet.dns_servers)
+            if subnet.dns_servers
+            else ""
+        )
 
         routes = [StaticRoute(**r) for r in subnet.routers]
 

--- a/exordos_core/tests/functional/restapi/compute/test_compute_boot_api.py
+++ b/exordos_core/tests/functional/restapi/compute/test_compute_boot_api.py
@@ -14,51 +14,149 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+"""The boot API, served the way the installation serves it: on its own.
+
+A process hosts one restalchemy application. `ResourceMap` is a class
+attribute and building an application *replaces* it, and the engine factory
+is a singleton the test harness configures and destroys per service -- so a
+second application in this process takes both away from the first. The
+product never asks it to: `ec-user-api` and `ec-boot-api` are separate units.
+This module used to ask it to, and what came of that was decided by the xdist
+layout -- a worker that met this class in the middle of its run spent the
+rest of it raising `Can not return default engine` at setup, or answering 404
+to any request body that named another resource by URI.
+
+So the boot API runs here as it runs there: its own process, reached over
+HTTP, with the options it would be started with on the command line. The
+database is this worker's, and the schema is the one the `user_api` fixture
+has already migrated -- the same schema the tests write their machines into.
+"""
+
+import contextlib
+import socket
+import subprocess
+import sys
+import tempfile
+import time
 import typing as tp
 from urllib.parse import urljoin
 import uuid as sys_uuid
 
-from oslo_config import cfg
 import pytest
 import requests
+from restalchemy.tests.functional import consts as ra_consts
 
-from exordos_core.boot_api.api import app as orch_app
-from exordos_core.cmd import boot_api as boot_api_cmd
 from exordos_core.common import constants as c
 from exordos_core.compute.dm import models
-from exordos_core.tests.functional import conftest
-from exordos_core.tests.functional import utils as test_utils
 
-CONF = cfg.CONF
+
+BOOT_API_STARTUP_TIMEOUT = 60.0
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+def _read(log: tp.IO[bytes]) -> str:
+    """Read back everything the service has written so far."""
+    log.seek(0)
+    return log.read().decode(errors="replace")
+
+
+def _wait_until_serving(
+    port: int, process: subprocess.Popen, log: tp.IO[bytes]
+) -> None:
+    """Wait for the port, and give up the moment the process is gone.
+
+    Waiting on a port alone turns a service that died on startup into a
+    timeout with nothing to read.
+    """
+    deadline = time.monotonic() + BOOT_API_STARTUP_TIMEOUT
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                "boot API exited with %s before serving:\n%s"
+                % (process.returncode, _read(log))
+            )
+        with contextlib.closing(
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        ) as probe:
+            probe.settimeout(0.2)
+            if probe.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.1)
+
+    process.kill()
+    raise RuntimeError("boot API did not start within %ss" % BOOT_API_STARTUP_TIMEOUT)
+
+
+@pytest.fixture()
+def boot_api(user_api) -> tp.Callable[..., str]:
+    """Start a boot API and return the base URL of its v1 API.
+
+    Takes the options the service takes on its command line, so a test says
+    what the installation would be configured with rather than reaching into
+    a config object it happens to share with the service.
+
+    Depends on `user_api` for the schema: it is the fixture that migrates
+    this worker's database before each test, and the boot API reads what the
+    test then writes into it.
+    """
+    processes: tp.List[tp.Tuple[subprocess.Popen, tp.IO[bytes]]] = []
+
+    def start(**options: str) -> str:
+        port = _free_port()
+        # `ec-boot-api` as a module rather than as the console script: same
+        # interpreter, same environment, and no dependence on whether this
+        # venv's bin directory happens to be on PATH.
+        argv = [
+            sys.executable,
+            "-m",
+            "exordos_core.cmd.boot_api",
+            "--boot_api-bind-host",
+            "127.0.0.1",
+            "--boot_api-bind-port",
+            str(port),
+            "--db-connection_url",
+            ra_consts.get_database_uri(),
+        ]
+        for name, value in options.items():
+            argv += ["--boot_api-%s" % name, str(value)]
+
+        # The service logs for as long as it runs and nothing here reads it
+        # while it does, so a pipe would fill its buffer and stop the service
+        # mid-test. A file takes all of it, and is still there to be read when
+        # the service dies before it ever serves.
+        log = tempfile.TemporaryFile()
+        process = subprocess.Popen(
+            argv,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+        processes.append((process, log))
+        _wait_until_serving(port, process, log)
+        return "http://127.0.0.1:%s/v1/" % port
+
+    yield start
+
+    for process, log in processes:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+        log.close()
 
 
 class TestComputeBootApi:
-    @pytest.fixture(scope="class")
-    def boot_api_service(self):
-        class ApiRestService(test_utils.RestServiceTestCase):
-            __FIRST_MIGRATION__ = conftest.FIRST_MIGRATION
-            __APP__ = test_utils.build_app(orch_app.build_wsgi_application)
-
-        rest_service = ApiRestService()
-        rest_service.setup_class()
-
-        yield rest_service
-
-        rest_service.teardown_class()
-
-    @pytest.fixture()
-    def boot_api(self, boot_api_service: test_utils.RestServiceTestCase):
-        boot_api_service.setup_method()
-
-        yield boot_api_service
-
-        boot_api_service.teardown_method()
-
-    def test_netboots_default_net(self, boot_api: test_utils.RestServiceTestCase):
-        CONF[boot_api_cmd.DOMAIN].gc_host = "10.20.0.2"
+    def test_netboots_default_net(self, boot_api: tp.Callable[..., str]):
+        base_url = boot_api(gc_host="10.20.0.2")
 
         uuid = sys_uuid.uuid4()
-        url = urljoin(boot_api.base_url, f"boots/{str(uuid)}")
+        url = urljoin(base_url, f"boots/{str(uuid)}")
 
         response = requests.get(url)
 
@@ -72,9 +170,9 @@ class TestComputeBootApi:
     def test_netboots_hd_boot(
         self,
         pool_factory: tp.Callable,
-        boot_api: test_utils.RestServiceTestCase,
+        boot_api: tp.Callable[..., str],
     ):
-        CONF[boot_api_cmd.DOMAIN].gc_host = "10.20.0.2"
+        base_url = boot_api(gc_host="10.20.0.2")
 
         pool_view = pool_factory()
         pool_view["status"] = "ACTIVE"
@@ -94,7 +192,7 @@ class TestComputeBootApi:
         )
         machine.insert()
 
-        url = urljoin(boot_api.base_url, f"boots/{machine.uuid}")
+        url = urljoin(base_url, f"boots/{machine.uuid}")
 
         response = requests.get(url)
 
@@ -108,13 +206,16 @@ class TestComputeBootApi:
         pool.delete()
 
     def test_netboots_default_net_custom_kernel_initrd(
-        self, boot_api: test_utils.RestServiceTestCase
+        self, boot_api: tp.Callable[..., str]
     ):
-        CONF[boot_api_cmd.DOMAIN].kernel = "https://kernel.org/vmlinuz"
-        CONF[boot_api_cmd.DOMAIN].initrd = "https://kernel.org/initrd.img"
+        base_url = boot_api(
+            gc_host="10.20.0.2",
+            kernel="https://kernel.org/vmlinuz",
+            initrd="https://kernel.org/initrd.img",
+        )
 
         uuid = sys_uuid.uuid4()
-        url = urljoin(boot_api.base_url, f"boots/{str(uuid)}")
+        url = urljoin(base_url, f"boots/{str(uuid)}")
 
         response = requests.get(url)
 

--- a/exordos_core/tests/functional/service/test_border_contract.py
+++ b/exordos_core/tests/functional/service/test_border_contract.py
@@ -1,0 +1,84 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""The border target resource is declared twice, like the evpn ones — here as
+what the control plane schedules, and in gcl_sdk as what the agent renders.
+It had no test saying so, and it is what the border cost: a `routes` the data
+plane dropped and the control plane kept sending failed *every* border
+resource, with a traceback that named neither the field nor the border.
+
+The agent now skips a name it does not have rather than dying on it, which
+turns that from an outage into a resource that never settles. This is what
+keeps it from being either.
+
+Lives with the functional suite because it imports the data-plane half, as
+the evpn contract test does — the unit environment resolves gcl_sdk from the
+index, where a published release can be older than both halves here.
+"""
+
+import pytest
+
+from exordos_core.network.border.dm import models as cp_models
+
+# The data-plane model ships in gcl_sdk, which this installation pins to a
+# published release. Skip with the remedy in the message rather than fail at
+# collection; an editable checkout of gcl_sdk runs this in full.
+dp_models = pytest.importorskip(
+    "gcl_sdk.paas.dm.border",
+    reason=(
+        "needs a gcl_sdk that carries the border data-plane model "
+        "(install gcl_sdk from a checkout to run this)"
+    ),
+)
+
+
+def _fields(model):
+    # `agent_uuid` is the CP's scheduling handle (which agent gets this
+    # resource), not part of the value the agent renders — the one field the
+    # two halves are meant to differ by.
+    return set(model.properties.properties.keys()) - {"uuid", "agent_uuid"}
+
+
+@pytest.mark.parametrize("cp", [cp_models.BorderAgent, cp_models.BorderNode])
+def test_the_control_plane_names_nothing_the_data_plane_lacks(cp):
+    """One data-plane model serves both kinds: what differs between them is
+    which agent the resource is scheduled to, not what it says.
+
+    Deliberately one-directional. Equality would be the stronger statement,
+    but it cannot hold while a field is being retired: dropping it from the
+    control plane has to ship *before* the release that drops it from the
+    data plane, or an installation that rebuilds picks up a data plane
+    missing a field the core still sends. `routes` is in exactly that
+    window, and asserting equality here would make the release that has to
+    come first the one that cannot.
+
+    The direction that is asserted is the one that breaks things. The other
+    is a field the agent has and is never given, which costs it its default.
+    """
+    assert _fields(cp) <= _fields(dp_models.Border)
+
+
+@pytest.mark.parametrize("cp", [cp_models.BorderAgent, cp_models.BorderNode])
+def test_target_fields_are_all_declared(cp):
+    """What the CP hashes into the target value has to exist on both sides.
+
+    A name only the CP has is worse than a value that does not arrive: it is
+    in the target hash the agent cannot reproduce, so the resource is applied
+    and re-applied for ever without ever matching.
+    """
+    assert set(cp().get_resource_target_fields()) <= _fields(dp_models.Border) | {
+        "uuid"
+    }

--- a/exordos_core/tests/unit/network/test_border_builder.py
+++ b/exordos_core/tests/unit/network/test_border_builder.py
@@ -44,17 +44,15 @@ def test_paasborder_getters_read_inline_rules():
     )
     assert border.get_snat_rules() == snat
     assert border.get_forwards() == forwards
-    assert border.get_routes() == []
 
 
-def _instance(snat=None, forwards=None, routes=None, node=None, kind="core_agent"):
+def _instance(snat=None, forwards=None, node=None, kind="core_agent"):
     inst = mock.MagicMock()
     inst.uuid = sys_uuid.uuid4()
     inst.node = node
     inst.type.kind = kind
     inst.get_snat_rules.return_value = snat or []
     inst.get_forwards.return_value = forwards or []
-    inst.get_routes.return_value = routes or []
     return inst
 
 
@@ -93,7 +91,6 @@ def test_produces_single_border_agent_passing_rules_through():
     assert agent.uuid == inst.uuid
     assert agent.snat_rules == snat
     assert agent.forwards == forwards
-    assert agent.routes == []
 
 
 def test_produces_border_node_when_target_node_set():
@@ -216,3 +213,16 @@ def test_status_error_when_any_actual_error():
         inst, _collection("ACTIVE", "ERROR")
     )
     assert inst.status == cc.ServiceStatus.ERROR.value
+
+
+def test_a_border_resource_names_no_field_the_data_plane_dropped():
+    """`routes` was sent empty by everything that built one and read by
+    nothing, and the data plane dropped it first. What a field costs when
+    only one side drops it is the whole capability: the agent builds its
+    model from the resource's keys, so one name it does not have failed
+    every border resource. The general check against the data-plane model
+    lives in the functional suite, which is where a gcl_sdk new enough to
+    have dropped it is the one installed."""
+    for model in (border_models.BorderAgent, border_models.BorderNode):
+        assert "routes" not in model.get_resource_target_fields(model)
+        assert "routes" not in set(model.properties.properties)

--- a/exordos_core/tests/unit/network/test_dhcp_config.py
+++ b/exordos_core/tests/unit/network/test_dhcp_config.py
@@ -1,0 +1,77 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""What the host's DHCP server is handed.
+
+One file serves every subnet of the installation, and `dhcpd` refuses the
+whole of it over a single syntax error — so what one subnet renders to is
+never only that subnet's business.
+"""
+
+import types
+
+import netaddr
+
+from exordos_core.network.dhcp import isc
+
+
+class _Subnet(types.SimpleNamespace):
+    """Enough of a Subnet for the renderer, without a database.
+
+    Hashable, because the renderer is handed a mapping keyed by subnet.
+    """
+
+    __hash__ = object.__hash__
+
+
+def _subnet(cidr, dns_servers=(), routers=(), next_server=None):
+    return _Subnet(
+        cidr=netaddr.IPNetwork(cidr),
+        dns_servers=list(dns_servers),
+        routers=list(routers),
+        next_server=next_server,
+        ip_discovery_range_pair=None,
+    )
+
+
+def test_a_subnet_that_names_a_resolver_hands_it_out():
+    config = isc.dhcp_config({_subnet("10.20.0.0/22", ["10.20.0.2"]): []})
+
+    assert "option domain-name-servers 10.20.0.2;" in config
+
+
+def test_a_subnet_with_no_resolver_says_nothing_about_resolvers():
+    """An option with no value is a syntax error, and one is enough to stop
+    the server for every network on the host: a pool of addresses nothing is
+    placed in names no resolver, and took PXE down installation-wide."""
+    config = isc.dhcp_config({_subnet("10.20.3.0/24"): []})
+
+    assert "domain-name-servers" not in config
+    assert "subnet 10.20.3.0 netmask 255.255.255.0" in config
+
+
+def test_a_pool_subnet_does_not_disturb_the_ones_beside_it():
+    config = isc.dhcp_config(
+        {
+            _subnet("10.20.3.0/24"): [],
+            _subnet("10.30.0.0/24", ["10.20.0.2"], next_server="10.30.0.2"): [],
+        }
+    )
+
+    assert "option domain-name-servers 10.20.0.2;" in config
+    assert "next-server 10.30.0.2;" in config
+    # Nothing dangles: every option that is written has a value.
+    assert "option domain-name-servers ;" not in config

--- a/exordos_core/tests/unit/user_api/iam/test_provisioning.py
+++ b/exordos_core/tests/unit/user_api/iam/test_provisioning.py
@@ -26,9 +26,16 @@ from exordos_core.user_api.iam.dm import models
 class TestProvisionPersonalWorkspace:
     @pytest.fixture
     def user(self):
-        u = models.User.__new__(models.User)
+        # Not `models.User.__new__(...)`: a model built without its
+        # constructor has no properties of its own, so each assignment lands
+        # in the class's shared declaration and every other `User` in the
+        # process — in this test run — starts reading these values. The
+        # method under test is called unbound on a stand-in instead.
+        u = mock.MagicMock(name_="testuser", uuid=uuid.uuid4())
         u.name = "testuser"
-        u.uuid = uuid.uuid4()
+        u.provision_personal_workspace = lambda: (
+            models.User.provision_personal_workspace(u)
+        )
         return u
 
     @pytest.fixture


### PR DESCRIPTION
## Summary by Sourcery

Harden provisioning and networking behavior ahead of SDN integration by fixing DHCP generation, aligning border resource contracts, isolating boot API tests, and tightening build and manifest configuration.

Bug Fixes:
- Prevent invalid empty DNS options from disabling DHCP configuration across all subnets.
- Remove unsupported border routing data from control-plane resources to keep them compatible with the data plane.
- Run boot API functional tests in an isolated service process to avoid cross-test application and database-engine interference.
- Prevent test user fixtures from mutating shared model state.

Enhancements:
- Align manifest examples with the core compute node reference.
- Exclude agent scaffolding from build inputs to avoid filling provisioning storage.
- Add contract coverage for border control-plane and data-plane resource compatibility.

Documentation:
- Update English and Russian manifest examples to use the core compute node reference.

Tests:
- Add DHCP configuration regression tests and border resource compatibility checks.
- Refactor boot API functional tests to exercise the service over HTTP in a separate process.