### PR TITLE
fix(repo): expose installation_state on the repo element API

### DIFF
--- a/docs/core-developer-guide/repo-proxy.md
+++ b/docs/core-developer-guide/repo-proxy.md
@@ -381,8 +381,8 @@ The User API is served under `/v1/repo/` and defined in
 
 - **Repository**: `status`, `created_at`, `updated_at` are read-only.
   `next_refresh` is hidden from API responses.
-- **RepoElement**: `status`, `created_at`, `updated_at` are read-only.
-  `installation_state` is hidden from API responses.
+- **RepoElement**: `status`, `installation_state`, `created_at`, `updated_at`
+  are read-only.
 
 ### IAM
 

--- a/docs/core-developer-guide/repo-proxy.ru.md
+++ b/docs/core-developer-guide/repo-proxy.ru.md
@@ -383,8 +383,8 @@ User API обслуживается по пути `/v1/repo/` и определ�
 
 - **Repository**: `status`, `created_at`, `updated_at` — только для чтения.
   `next_refresh` скрыт в ответах API.
-- **RepoElement**: `status`, `created_at`, `updated_at` — только для чтения.
-  `installation_state` скрыт в ответах API.
+- **RepoElement**: `status`, `installation_state`, `created_at`, `updated_at`
+  — только для чтения.
 
 ### IAM
 

--- a/exordos_core/user_api/repo/api/controllers.py
+++ b/exordos_core/user_api/repo/api/controllers.py
@@ -96,11 +96,11 @@ class RepoElementController(
             default=field_p.Permissions.RW,
             fields={
                 "status": {ra_c.ALL: field_p.Permissions.RO},
+                "installation_state": {ra_c.ALL: field_p.Permissions.RO},
                 "created_at": {ra_c.ALL: field_p.Permissions.RO},
                 "updated_at": {ra_c.ALL: field_p.Permissions.RO},
             },
         ),
-        hidden_fields=["installation_state"],
     )
 
     def get(self, uuid, **kwargs):


### PR DESCRIPTION
The repo element `installation_state` was hidden from API responses, which broke CLI element selection right after an upgrade: the freshly installed element is `INSTALLED` but its `status` is still `NEW`, while the stale element being replaced is `UNINSTALLED` but still `ACTIVE`. With `installation_state` invisible, the CLI fell back to `status` and picked the stale element, so `ee uninstall` hit the server with an already-`UNINSTALLED` UUID and got a misleading 500 "Element must be installed".

Expose `installation_state` as a read-only field (it is not sensitive) so clients can select the truly installed element. Update the repo-proxy field-permissions doc accordingly.

Closes #590

## Summary by Sourcery

Expose RepoElement installation state as a read-only API field to ensure clients select the correct installed element.

Bug Fixes:
- Expose RepoElement installation state in API responses so clients can identify the currently installed element correctly after upgrades.

Documentation:
- Update repository proxy field-permissions documentation to mark RepoElement installation_state as read-only.