### PR TITLE
fix(iam): use policy controller without project

### DIFF
--- a/exordos_core/user_api/repo/api/controllers.py
+++ b/exordos_core/user_api/repo/api/controllers.py
@@ -83,7 +83,7 @@ class RepositoryController(
 
 
 class RepoElementController(
-    iam_controllers.PolicyBasedController,
+    iam_controllers.PolicyBasedWithoutProjectController,
     controllers.BaseResourceControllerPaginated,
 ):
     __policy_service_name__ = "repo"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use the IAM policy controller that does not require a project for repository element authorization.