### PR TITLE
perf(tests): speed up functional tests

### DIFF
--- a/exordos_core/tests/functional/conftest.py
+++ b/exordos_core/tests/functional/conftest.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import hashlib
 import json
 import os
 import tempfile
@@ -64,6 +65,22 @@ from exordos_core.user_api.network.dm import models as network_models
 
 FIRST_MIGRATION = "0000-root-d34de1.py"
 TEST_UUID_PREFIX = element_utils.UUID_PREFIX[::-1]
+
+# Password hashing dominates the runtime of this suite: every login and every
+# user creation runs PBKDF2 with the production iteration count, which costs
+# ~0.14s and happens thousands of times per run. The tests only need hashes to
+# be self-consistent, so cap the iterations. The application and the migrations
+# that seed the admin credentials both call hashlib.pbkdf2_hmac, so patching it
+# here keeps the two in agreement.
+TEST_PBKDF2_ITERATIONS = 1
+_pbkdf2_hmac = hashlib.pbkdf2_hmac
+
+
+def _fast_pbkdf2_hmac(hash_name, password, salt, iterations, dklen=None):
+    return _pbkdf2_hmac(hash_name, password, salt, TEST_PBKDF2_ITERATIONS, dklen)
+
+
+hashlib.pbkdf2_hmac = _fast_pbkdf2_hmac
 
 
 def _make_uuid() -> sys_uuid.UUID:
@@ -190,7 +207,8 @@ def user_api_service(context_storage):
 
 @pytest.fixture()
 def user_api(user_api_service: test_utils.RestServiceTestCase):
-    # TODO(slashburygin): setup_method(apply_migrations) should be called once, not every test. Should be fixed after squash migrations
+    # setup_method applies the migrations once and resets the database by
+    # truncating it before every later test.
     user_api_service.setup_method()
 
     # Keep the legacy baseline for tests: no implicit personal workspace
@@ -258,12 +276,6 @@ def auth_test1_user(
 
     yield auth
 
-    try:
-        admin_client = user_api_client(auth_user_admin)
-        admin_client.delete_user(auth.uuid)
-    except Exception:
-        pass
-
 
 @pytest.fixture()
 def auth_test2_user(
@@ -298,12 +310,6 @@ def auth_test2_user(
     )
 
     yield auth
-
-    try:
-        admin_client = user_api_client(auth_user_admin)
-        admin_client.delete_user(auth.uuid)
-    except Exception:
-        pass
 
 
 @pytest.fixture()
@@ -361,22 +367,6 @@ def auth_test1_p1_user(
 
     yield result
 
-    try:
-        admin_client = user_api_client(auth_user_admin)
-        admin_client.delete_project(project["uuid"])
-    except Exception:
-        pass
-    try:
-        admin_client = user_api_client(auth_user_admin)
-        admin_client.delete_organization(org["uuid"])
-    except Exception:
-        pass
-    try:
-        admin_client = user_api_client(auth_user_admin)
-        admin_client.delete_user(user["uuid"])
-    except Exception:
-        pass
-
 
 @pytest.fixture()
 def auth_test2_p1_user(
@@ -427,22 +417,6 @@ def auth_test2_p1_user(
     )
 
     yield result
-
-    try:
-        admin_client = user_api_client(auth_user_admin)
-        admin_client.delete_project(project["uuid"])
-    except Exception:
-        pass
-    try:
-        admin_client = user_api_client(auth_user_admin)
-        admin_client.delete_organization(org["uuid"])
-    except Exception:
-        pass
-    try:
-        admin_client = user_api_client(auth_user_admin)
-        admin_client.delete_user(user["uuid"])
-    except Exception:
-        pass
 
 
 @pytest.fixture()
@@ -1191,12 +1165,6 @@ def default_pool(
 
     yield default_pool
 
-    url = client.build_resource_uri(["compute", "hypervisors", str(uuid)])
-    try:
-        client.delete(url)
-    except Exception:
-        pass
-
 
 @pytest.fixture
 def default_node(
@@ -1211,9 +1179,6 @@ def default_node(
     client.post(url, json=default_node)
 
     yield default_node
-
-    url = client.build_resource_uri(["compute", "nodes", uuid])
-    client.delete(url)
 
 
 @pytest.fixture
@@ -1230,11 +1195,6 @@ def default_network(
     network.insert()
 
     yield network
-
-    try:
-        network.delete()
-    except Exception:
-        pass
 
 
 @pytest.fixture
@@ -1254,11 +1214,6 @@ def default_subnet(
 
     yield subnet
 
-    try:
-        subnet.delete()
-    except Exception:
-        pass
-
 
 @pytest.fixture
 def default_machine_agent(
@@ -1277,11 +1232,6 @@ def default_machine_agent(
     agent.insert()
 
     yield agent.dump_to_simple_view()
-
-    try:
-        agent.delete()
-    except Exception:
-        pass
 
 
 @pytest.fixture
@@ -1307,11 +1257,6 @@ def default_pool_builder(
     agent.insert()
 
     yield agent.dump_to_simple_view()
-
-    try:
-        agent.delete()
-    except Exception:
-        pass
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/exordos_core/tests/functional/conftest.py
+++ b/exordos_core/tests/functional/conftest.py
@@ -207,8 +207,8 @@ def user_api_service(context_storage):
 
 @pytest.fixture()
 def user_api(user_api_service: test_utils.RestServiceTestCase):
-    # setup_method applies the migrations once and resets the database by
-    # truncating it before every later test.
+    # setup_method applies the migrations once and empties the database
+    # before every later test.
     user_api_service.setup_method()
 
     # Keep the legacy baseline for tests: no implicit personal workspace
@@ -421,6 +421,13 @@ def auth_test2_p1_user(
 
 @pytest.fixture()
 def user_api_client(user_api, auth_user_admin):
+    # Built once per test rather than once per build_client call: the client
+    # authenticates lazily, so every extra instance costs another token
+    # request.
+    admin_client = iam_clients.GenericAutoRefreshRESTClient(
+        f"{user_api.get_endpoint()}v1/",
+        auth_user_admin,
+    )
 
     def build_client(
         auth: iam_clients.GenesisCoreAuth,
@@ -432,14 +439,22 @@ def user_api_client(user_api, auth_user_admin):
             f"{user_api.get_endpoint()}v1/",
             auth,
         )
-        admin_client = iam_clients.GenericAutoRefreshRESTClient(
-            f"{user_api.get_endpoint()}v1/",
-            auth_user_admin,
-        )
 
-        admin_client.set_permissions_to_user(
+        # This is set_permissions_to_user without its lookups. That helper
+        # looks the role and the role binding up before creating them, but the
+        # role name is a fresh uuid, so neither lookup can ever hit.
+        role = admin_client.create_role(name=f"TestRole[{sys_uuid.uuid4()}]")
+        for permission_name in permissions:
+            permission = admin_client.create_or_get_permission(
+                name=str(permission_name),
+            )
+            admin_client.create_permission_binding(
+                permission_uuid=permission["uuid"],
+                role_uuid=role["uuid"],
+            )
+        admin_client.bind_role_to_user(
+            role_uuid=role["uuid"],
             user_uuid=auth.uuid,
-            permissions=permissions,
             project_id=project_id,
         )
 

--- a/exordos_core/tests/functional/utils.py
+++ b/exordos_core/tests/functional/utils.py
@@ -27,6 +27,8 @@ from restalchemy.tests.functional import db_utils as ra_db_utils
 from restalchemy.tests.functional.restapi.ra_based.microservice import service
 
 ENDPOINT_TEMPLATE = "http://127.0.0.1:%s/"
+# Prefix of the shadow tables holding the rows the migrations seed.
+SEED_TABLE_PREFIX = "seed_snapshot_"
 
 
 class RestServiceTestCase(ra_db_utils.DBEngineMixin):
@@ -166,7 +168,7 @@ class RestServiceTestCase(ra_db_utils.DBEngineMixin):
     def setup_method(self) -> None:
         # Rebuilding the whole schema before every test costs ~0.5s. Do it
         # once, snapshot the rows the migrations seed, and reset later tests
-        # by truncating and restoring that snapshot instead (~0.08s). The
+        # by emptying the tables and restoring that snapshot (~0.01s). The
         # snapshot is only usable while the schema it was taken from is still
         # there -- another service's teardown_method/teardown_class shares the
         # database and may have dropped it.
@@ -195,23 +197,34 @@ class RestServiceTestCase(ra_db_utils.DBEngineMixin):
             row["table_name"]
             for row in rows
             if row["table_name"] != migrations.RA_MIGRATION_TABLE_NAME
+            and not row["table_name"].startswith(SEED_TABLE_PREFIX)
         )
 
     def _take_seed_snapshot(self) -> tp.Dict[str, tp.Any]:
         with self.engine.session_manager() as s:
             tables = self._base_tables(s)
-            rows_by_table = {}
+            # Copy the seeded rows into shadow tables so that resetting is a
+            # server-side INSERT ... SELECT rather than a round trip per row.
+            seeded = []
             for table in tables:
-                rows = s.execute(f'select * from "{table}"').fetchall()
-                if rows:
-                    rows_by_table[table] = (
-                        list(rows[0].keys()),
-                        [tuple(row.values()) for row in rows],
-                    )
-            sequences = {
-                row["sequence_name"]: s.execute(
-                    f"""select last_value, is_called from "{row["sequence_name"]}";"""
-                ).fetchall()[0]
+                s.execute(f'DROP TABLE IF EXISTS "{SEED_TABLE_PREFIX}{table}"')
+                s.execute(
+                    f'CREATE TABLE "{SEED_TABLE_PREFIX}{table}" AS TABLE "{table}"'
+                )
+                if s.execute(
+                    f'SELECT 1 FROM "{SEED_TABLE_PREFIX}{table}" LIMIT 1'
+                ).fetchall():
+                    seeded.append(table)
+                else:
+                    s.execute(f'DROP TABLE "{SEED_TABLE_PREFIX}{table}"')
+            sequences = [
+                (
+                    row["sequence_name"],
+                    s.execute(
+                        f"""select last_value, is_called
+                            from "{row["sequence_name"]}";"""
+                    ).fetchall()[0],
+                )
                 for row in s.execute(
                     """
                     select sequence_name as sequence_name
@@ -219,44 +232,36 @@ class RestServiceTestCase(ra_db_utils.DBEngineMixin):
                     where sequence_schema = current_schema();
                     """
                 ).fetchall()
-            }
-        return {
-            "tables": set(tables),
-            "truncate": "TRUNCATE "
-            + ",".join(f'"{table}"' for table in tables)
-            + " RESTART IDENTITY CASCADE",
-            "rows": rows_by_table,
-            "sequences": sequences,
-        }
+            ]
+
+        # The whole reset is one multi-statement round trip. SET LOCAL keeps
+        # the constraint triggers disabled for this transaction only, so a
+        # failed reset cannot hand a pooled connection back with foreign keys
+        # still off; they have to be off because the seeded rows reference
+        # each other and cannot be restored in any FK-satisfying order.
+        # DELETE rather than TRUNCATE: almost every table is empty by the end
+        # of a test, and DELETE barely touches those, while TRUNCATE rewrites
+        # each of them regardless (0.008s against 0.12s for the whole schema).
+        # The sequences are restored below, so RESTART IDENTITY is not needed.
+        statements = ["SET LOCAL session_replication_role = replica"]
+        statements += [f'DELETE FROM "{table}"' for table in tables]
+        statements += [
+            f'INSERT INTO "{table}" SELECT * FROM "{SEED_TABLE_PREFIX}{table}"'
+            for table in seeded
+        ]
+        statements += [
+            f"SELECT setval('{name}', {state['last_value']}, {state['is_called']})"
+            for name, state in sequences
+        ]
+        return {"tables": set(tables), "reset": ";\n".join(statements)}
 
     def _snapshot_is_usable(self) -> bool:
         with self.engine.session_manager() as s:
             return set(self._base_tables(s)) == self._seed_snapshot["tables"]
 
     def _restore_seed_snapshot(self) -> None:
-        snapshot = self._seed_snapshot
         with self.engine.session_manager() as s:
-            # Seeded rows reference each other, so they cannot be restored in
-            # an order that satisfies every foreign key. Turn the constraint
-            # triggers off for the restore instead of topologically sorting.
-            # SET LOCAL keeps the override on this transaction, so a failed
-            # restore cannot hand a pooled connection back with foreign keys
-            # still disabled.
-            s.execute("SET LOCAL session_replication_role = replica")
-            s.execute(snapshot["truncate"])
-            for table, (columns, rows) in snapshot["rows"].items():
-                column_list = ",".join(f'"{column}"' for column in columns)
-                placeholders = ",".join(["%s"] * len(columns))
-                statement = (
-                    f'INSERT INTO "{table}" ({column_list}) VALUES ({placeholders})'
-                )
-                for row in rows:
-                    s.execute(statement, row)
-            for sequence, state in snapshot["sequences"].items():
-                s.execute(
-                    f"select setval('{sequence}', %s, %s)",
-                    (state["last_value"], state["is_called"]),
-                )
+            s.execute(self._seed_snapshot["reset"])
 
     def rollback_migrations(self) -> None:
         # Rollback migrations

--- a/exordos_core/tests/functional/utils.py
+++ b/exordos_core/tests/functional/utils.py
@@ -35,6 +35,8 @@ class RestServiceTestCase(ra_db_utils.DBEngineMixin):
     __API_VERSION__ = "v1"
     __APP__ = None
 
+    _seed_snapshot: tp.Optional[tp.Dict[str, tp.Any]] = None
+
     @classmethod
     def get_endpoint(cls, template: str = ENDPOINT_TEMPLATE) -> str:
         return template % cls.service_port
@@ -162,8 +164,99 @@ class RestServiceTestCase(ra_db_utils.DBEngineMixin):
             s.execute(f"drop view if exists {session.engine.escape(view_name)}")
 
     def setup_method(self) -> None:
-        # Apply migrations
+        # Rebuilding the whole schema before every test costs ~0.5s. Do it
+        # once, snapshot the rows the migrations seed, and reset later tests
+        # by truncating and restoring that snapshot instead (~0.08s). The
+        # snapshot is only usable while the schema it was taken from is still
+        # there -- another service's teardown_method/teardown_class shares the
+        # database and may have dropped it.
+        if self._seed_snapshot is not None and self._snapshot_is_usable():
+            self._restore_seed_snapshot()
+            return
+
         self.apply_all_migrations()
+        self._seed_snapshot = (
+            self._take_seed_snapshot()
+            if self.engine.dialect.name == "postgresql"
+            else None
+        )
+
+    @classmethod
+    def _base_tables(cls, session) -> tp.List[str]:
+        rows = session.execute(
+            """
+            select table_name as table_name
+            from information_schema.tables
+            where table_schema = current_schema()
+              and table_type = 'BASE TABLE';
+            """
+        ).fetchall()
+        return sorted(
+            row["table_name"]
+            for row in rows
+            if row["table_name"] != migrations.RA_MIGRATION_TABLE_NAME
+        )
+
+    def _take_seed_snapshot(self) -> tp.Dict[str, tp.Any]:
+        with self.engine.session_manager() as s:
+            tables = self._base_tables(s)
+            rows_by_table = {}
+            for table in tables:
+                rows = s.execute(f'select * from "{table}"').fetchall()
+                if rows:
+                    rows_by_table[table] = (
+                        list(rows[0].keys()),
+                        [tuple(row.values()) for row in rows],
+                    )
+            sequences = {
+                row["sequence_name"]: s.execute(
+                    f"""select last_value, is_called from "{row["sequence_name"]}";"""
+                ).fetchall()[0]
+                for row in s.execute(
+                    """
+                    select sequence_name as sequence_name
+                    from information_schema.sequences
+                    where sequence_schema = current_schema();
+                    """
+                ).fetchall()
+            }
+        return {
+            "tables": set(tables),
+            "truncate": "TRUNCATE "
+            + ",".join(f'"{table}"' for table in tables)
+            + " RESTART IDENTITY CASCADE",
+            "rows": rows_by_table,
+            "sequences": sequences,
+        }
+
+    def _snapshot_is_usable(self) -> bool:
+        with self.engine.session_manager() as s:
+            return set(self._base_tables(s)) == self._seed_snapshot["tables"]
+
+    def _restore_seed_snapshot(self) -> None:
+        snapshot = self._seed_snapshot
+        with self.engine.session_manager() as s:
+            # Seeded rows reference each other, so they cannot be restored in
+            # an order that satisfies every foreign key. Turn the constraint
+            # triggers off for the restore instead of topologically sorting.
+            # SET LOCAL keeps the override on this transaction, so a failed
+            # restore cannot hand a pooled connection back with foreign keys
+            # still disabled.
+            s.execute("SET LOCAL session_replication_role = replica")
+            s.execute(snapshot["truncate"])
+            for table, (columns, rows) in snapshot["rows"].items():
+                column_list = ",".join(f'"{column}"' for column in columns)
+                placeholders = ",".join(["%s"] * len(columns))
+                statement = (
+                    f'INSERT INTO "{table}" ({column_list}) VALUES ({placeholders})'
+                )
+                for row in rows:
+                    s.execute(statement, row)
+            for sequence, state in snapshot["sequences"].items():
+                s.execute(
+                    f"select setval('{sequence}', %s, %s)",
+                    (state["last_value"], state["is_called"]),
+                )
 
     def rollback_migrations(self) -> None:
         # Rollback migrations


### PR DESCRIPTION
Functional tests went from **105s wall / 811s CPU** to **20s wall / 68s CPU** on an idle machine. The CPU figure is what matters on CI, where the runners have four vCPUs.

| | before | after |
|---|---|---|
| wall | 105s | 20s |
| CPU (user) | 811s | 68s |
| SQL statements per run | 157,634 | 62,937 |
| HTTP requests per run | 7,140 | 5,039 |

No test was changed, skipped or relaxed: 495 passed / 4 skipped throughout.

## Migrations are applied once, not per test

`setup_method` rebuilt the entire schema before every test — a rollback plus a re-apply of the 123KB squashed migration, 0.57s times 479 tests. It now migrates once, snapshots the rows the migrations seed into `seed_snapshot_*` shadow tables, and resets later tests with a single multi-statement round trip: `DELETE` from every table, `INSERT ... SELECT` the seeded rows back, `setval` the sequences. That is ~0.01s.

This resolves the `TODO(slashburygin)` on the `user_api` fixture.

Two details worth reviewing:

- The restore runs under `SET LOCAL session_replication_role = replica`. The seeded rows reference each other, so there is no insert order that satisfies every foreign key. `SET LOCAL` scopes the override to the transaction, so a failed reset cannot hand a pooled connection back with foreign keys still disabled.
- `DELETE` rather than `TRUNCATE`. Almost every table is empty when a test ends and `DELETE` barely touches those, while `TRUNCATE` rewrites all 66 regardless: 0.008s against 0.12s for the whole schema. `DELETE` leaves dead tuples, so this was stress-tested over 600 reset cycles — the reset drifts from 7.6ms to 10.5ms, still 12x better than `TRUNCATE`, and each worker only performs ~50 resets per run.

`test_compute_boot_api` builds its own service and drops the schema in its teardown, so the fast path verifies the table set still matches before trusting the snapshot, and falls back to a full migration when it does not.

## Fixture teardowns that the reset makes redundant

The auth and `default_*` fixtures deleted users, organizations, projects, nodes and pools on teardown. The reset already removes those rows. The expensive ones went through the API and rebuilt an admin client for each delete, which meant a full password grant per deletion. Teardown across the suite: 198s to 38s.

## PBKDF2 iteration count capped for the functional suite

After the two changes above, password hashing was **456s of the remaining 616s of CPU**: 3,367 hashes at the production iteration count of 251,685, at 0.138s apiece.

`hashlib.pbkdf2_hmac` is now patched at conftest import. The application and the migration that seeds the admin credentials both go through `hashlib`, so they stay in agreement.

**This is a deliberate tradeoff and the main thing to push back on if you disagree:** the functional suite no longer exercises the production iteration count. Only one test touches `secret_hash` (`test_reset_password.py`), and it compares before against after rather than asserting a value.

## IAM fixture setup

`set_permissions_to_user` searches for the role and the role binding before creating them, but the role name it generates is a fresh uuid, so neither lookup can ever hit. Inlined without them. The admin client is also built once per test rather than once per `user_api_client()` call — it authenticates lazily, so every extra instance cost another token request.

## Verification

- `tox -e py314-functional` — 495 passed, 4 skipped
- Stable across three consecutive runs at `-n 10` and one at `-n 20`
- `tox -e py314` — 252 unit tests pass
- `tox -e ruff-check` — clean

`tox.ini` is untouched. CI runs on 4-vCPU runners, so the CPU reduction is what helps there; raising `-n` would not.

## Noted, not changed

- The suite fails at `-n 4` on master as well (~385 errors, `ValueError: Can not return default engine`). `test_compute_boot_api.py` builds its own `RestServiceTestCase` whose `teardown_class` destroys the shared engine, and whether that breaks later tests depends on how xdist distributes them. Pre-existing, but it means the `-n 10` in `tox.ini` is load-bearing.
- `tox -e mypy` fails on master too (596 pre-existing errors); it does not cover tests.

https://claude.ai/code/session_015omd5qVJwXK2PTzuPQqwuP

## Summary by Sourcery

Accelerate the functional test suite by optimizing database resets, authentication setup, password hashing, and fixture cleanup.

Enhancements:
- Speed up functional tests by reusing a session-level migration snapshot to reset seeded database state between tests.
- Reduce functional-test authentication overhead by reusing the admin client and avoiding redundant permission lookups.
- Use a lower PBKDF2 cost in the functional test environment while keeping application and seeded credentials consistent.

Tests:
- Simplify functional-test fixture cleanup by relying on centralized database resets instead of deleting created resources through the API.
