### PR TITLE
feat(core): export default IAM client UUID variable

### DIFF
--- a/exordos/manifests/core.yaml.j2
+++ b/exordos/manifests/core.yaml.j2
@@ -1055,6 +1055,8 @@ exports:
     link: "$core.vs.variables.$hs256_jwks_encryption_key"
   var_iam_default_client_id:
     link: "$core.vs.variables.$iam_default_client_id"
+  var_iam_default_client_uuid:
+    link: "$core.vs.variables.$iam_default_client_uuid"
   profile_develop:
     link: "$core.vs.profiles.$develop"
   profile_small:


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Export the default IAM client UUID as a core manifest variable.