### PR TITLE
Speed up the FuncTests job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,15 +68,27 @@ jobs:
         run: |
           exordos settings set-realm default --endpoint $CORE_ENDPOINT_URL
           exordos settings set-context default --name default --user $CORE_USERNAME --password $CORE_PASSWORD
-      - name: Install hypervisor
-        run: |
-          EXORDOS_BIN=$(which exordos)
-          sudo $EXORDOS_BIN compute hypervisors init
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
           name: build_artifacts
           path: artifacts/
+      - name: Install hypervisor
+        run: |
+          set -eux
+          VERSION=$(cat artifacts/version.txt)
+
+          # Prefetch the core artifacts into ~/.cache/exordos while the
+          # hypervisor packages are being installed: both steps are
+          # independent and each takes around half a minute.
+          exordos bootstrap -i $VERSION -m core --download-only > prefetch.log 2>&1 &
+          PREFETCH_PID=$!
+
+          EXORDOS_BIN=$(which exordos)
+          sudo $EXORDOS_BIN compute hypervisors init
+
+          wait $PREFETCH_PID || { cat prefetch.log; exit 1; }
+          cat prefetch.log
       - name: bootstrap exordos core
         run: |
           VERSION=$(cat artifacts/version.txt)
@@ -86,13 +98,17 @@ jobs:
         run: |
           set -eux
           
-          for i in {1..20}; do
+          for i in {1..60}; do
             if exordos ready_api; then
               echo "Exordos Core API is ready"
               break
             fi
-            echo "Waiting for Exordos Core API... ($i/20)"
-            sleep 5
+            if [ "$i" -eq 60 ]; then
+              echo "Exordos Core API did not become ready"
+              exit 1
+            fi
+            echo "Waiting for Exordos Core API... ($i/60)"
+            sleep 2
           done
           
           while [ $(exordos ee l -o json -f name=core | jq -r .[0]."status") != "ACTIVE" ]; do


### PR DESCRIPTION
## Summary

The `FuncTests` job took 3m14s, and two chunks of that were avoidable: the
1.2 GB core image was downloaded *after* the hypervisor packages were
installed even though the two are independent, and the readiness poll
overshot by up to 7s per attempt. Expected job time drops to roughly 2m30s.

Timings below come from run `32826896789` (Actions API step timings plus the
job log), not from estimates:

| step | time | what it actually is |
|---|---|---|
| setup + checkout + packer + install exordos + config | 15s | |
| Install hypervisor | 38s | 35s of it is `apt install` inside `hypervisors init` |
| Download build artifacts | 0s | the artifact is just `version.txt` |
| bootstrap exordos core | 62s | 50s downloading the 1.2 GB qcow2, 12s launching |
| check exordos core | 79s | 73s polling `ready_api`, ~6s of real checks |

## Changes

- Prefetch the core artifacts with `exordos bootstrap --download-only` in the
  background, so the 1.2 GB image pull overlaps the ~35s `apt install` rather
  than following it. The real `bootstrap` then hits a warm
  `~/.cache/exordos/`. Saves ~38s.
- Move `Download build artifacts` ahead of the hypervisor install so
  `VERSION` is available for the prefetch. The step costs 0s — the artifact
  only carries `version.txt`.
- Poll `ready_api` every 2s instead of 5s. Each CLI call itself costs ~1.5s,
  so the old loop overshot by up to 7s.
- Fail the readiness step explicitly when the API never comes up. It used to
  fall through silently, leaving the unbounded `while ... ACTIVE` loop to burn
  the full 10-minute step timeout; it now exits 1, which correctly triggers
  the existing upterm debug step.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- `bash -n` over every `run:` block in the `FuncTests` job — shell syntax OK.
- `exordos bootstrap -i <bad-version> -m core --download-only` run locally —
  confirms the flag parses, needs no root or libvirt, and populates
  `~/.cache/exordos/exordos-elements/core/<version>/`.
- `tox` was **not** run: this change is CI configuration only and touches no
  Python.
- The end-to-end saving is **not yet verified** — that needs a real CI run,
  and I did not pull 1.2 GB locally to simulate it. Worth watching on the
  first run of this branch: if the `bootstrap` step still shows a ~50s
  download, then `-f` is invalidating the prefetched cache and the split
  needs reworking.

## Not addressed

- `FuncTests` idles through `Build`'s 4m41s while doing ~53s of
  Build-independent setup. Reclaiming it means dropping `needs: Build` and
  polling for the artifact manually — real fragility for ~50s of wall clock.
- `Setup packer` (2s) looks vestigial in this job (packer builds images; this
  job only launches a prebuilt qcow2 via libvirt), but not worth the risk for
  2s.
- The 50s image pull and 73s VM boot are genuine work; caching does not help
  since the image is version-tagged per build.

https://claude.ai/code/session_018n3HHEZYZsUq8Fh5QzLifr

## Summary by Sourcery

Accelerate the FuncTests workflow by parallelizing independent setup work and making Core readiness failures explicit.

Bug Fixes:
- Fail the functional test job when the Exordos Core API does not become ready instead of allowing the readiness step to time out silently.

Enhancements:
- Reduce functional test startup time by overlapping core artifact downloads with hypervisor installation and shortening API readiness polling intervals.

CI:
- Reorder functional test workflow steps so build artifacts are available before hypervisor setup and core prefetching begins.

Tests:
- Validate the workflow YAML and embedded shell commands, and verify the bootstrap download-only option locally.