### PR TITLE
Add Python, uv and ruff badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-![Tests workflow](https://github.com/infraguys/exordos_core/actions/workflows/tests.yml/badge.svg)
-![Build workflow](https://github.com/infraguys/exordos_core/actions/workflows/build.yml/badge.svg)
-![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)
+[![Tests](https://img.shields.io/github/actions/workflow/status/exordos/exordos_core/tests.yml?branch=master&label=tests&logo=github&style=flat-square)](https://github.com/exordos/exordos_core/actions/workflows/tests.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/exordos/exordos_core/build.yml?branch=master&label=build&logo=github&style=flat-square)](https://github.com/exordos/exordos_core/actions/workflows/build.yml)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-3776AB?logo=python&logoColor=white&style=flat-square)](https://www.python.org/)
+[![uv](https://img.shields.io/badge/uv-managed-DE5FE9?logo=uv&logoColor=white&style=flat-square)](https://github.com/astral-sh/uv)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-D7FF64?logo=ruff&logoColor=black&style=flat-square)](https://github.com/astral-sh/ruff)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://www.apache.org/licenses/LICENSE-2.0)
 
 <p align="center">
   <picture>


### PR DESCRIPTION
## Summary

Rounds out the README badge row with the parts of the toolchain that were
missing — supported Python versions, uv-managed dependencies and ruff
formatting — and fixes the workflow badges, which still pointed at the old
`infraguys/exordos_core` path.

## Changes

- Add `python`, `uv` and `code style: ruff` badges, with values taken from
  `pyproject.toml` (`requires-python` / classifiers), `uv.lock` +
  `astral-sh/setup-uv` in CI, and `[tool.ruff]` / `tox -e ruff-check`
- Repoint the tests and build badges at `exordos/exordos_core`, matching the
  actual `origin` remote
- Unify all six badges on shields.io `flat-square` and make each one link to
  its target — previously the workflow badges rendered at a different height
  than the license badge and none of them were clickable

Note: `pyproject.toml`'s `homepage` still points at `infraguys` — out of
scope here, worth a separate fix.

## Verification

- `make mdlint` — 68 files, 0 errors
- Each badge URL fetched with `curl`: all return HTTP 200 with the expected
  `<title>` (`tests: passing`, `build: passing`, `python: 3.10 | … | 3.14`,
  `uv: managed`, `code style: ruff`, `license: Apache 2.0`)
- Test suite not run: the change is Markdown-only and touches no code

https://claude.ai/code/session_01PQYqmeYo185JyeL7MN9Zrt

## Summary by Sourcery

Refresh the README badge row to accurately represent the project toolchain and repository workflows.

New Features:
- Add clickable README badges for supported Python versions, uv dependency management, and Ruff code style.

Bug Fixes:
- Correct the tests and build workflow badges to reference the current repository path.

Enhancements:
- Standardize all README badges on shields.io flat-square styling.

Documentation:
- Update the README badge row to link each project status, toolchain, and licensing badge to its relevant destination.