### PR TITLE
docs(usage): fix architecture page icon for zensical build

### DIFF
--- a/docs/usage/architecture.md
+++ b/docs/usage/architecture.md
@@ -1,5 +1,5 @@
 ---
-icon: lucide/sitemap
+icon: lucide/layers
 ---
 # Exordos Core Architecture
 

--- a/docs/usage/architecture.ru.md
+++ b/docs/usage/architecture.ru.md
@@ -1,5 +1,5 @@
 ---
-icon: lucide/sitemap
+icon: lucide/layers
 ---
 # Архитектура Exordos Core
 


### PR DESCRIPTION
## Summary

- Replace `lucide/sitemap` page icon with `lucide/layers` in the
  architecture pages (EN/RU). `lucide/sitemap` is not bundled in
  zensical 0.0.51, which broke `tox -e docs-build` with
  `template not found: ... lucide/sitemap.svg`. `lucide/layers` is
  already used by `em/resources` and is available in the bundled icon
  set.

#### Test plan

- [x] `tox -e docs-build` passes locally
- [x] `zensical build --clean --strict` passes (no `template not found`)

Generated with [Devin](https://devin.ai)

## Summary by Sourcery

Use a bundled icon for the architecture documentation pages so Zensical builds complete successfully.

Bug Fixes:
- Fix documentation builds by replacing the unavailable architecture page icon in the English and Russian pages.

Documentation:
- Update architecture page icons to use a bundled icon supported by Zensical.