### PR TITLE
fix(iam): use organization name in project error

### DIFF
--- a/exordos_core/user_api/iam/api/controllers.py
+++ b/exordos_core/user_api/iam/api/controllers.py
@@ -472,7 +472,7 @@ class ProjectController(controllers.BaseResourceControllerPaginated, EnforceMixi
             or self.enforce(c.PERMISSION_PROJECT_WRITE_ALL)
             or self.enforce(c.PERMISSION_ORGANIZATION_WRITE_ALL)
         ):
-            raise iam_e.CanNotCreateProjectInOrganization(uuid=organization.uuid)
+            raise iam_e.CanNotCreateProjectInOrganization(name=organization.name)
 
         project = super().create(organization=organization, **kwargs)
         project.add_owner(models.User.me())

--- a/exordos_core/user_api/iam/exceptions.py
+++ b/exordos_core/user_api/iam/exceptions.py
@@ -129,7 +129,7 @@ class CanNotCreateProjectInOrganization(
 ):
     __template__ = (
         "The current user is not permitted to create a project in the"
-        " organization `{uuid}`. Only the owner of the organization may"
+        " organization `{name}`. Only the owner of the organization may"
         " create projects."
     )
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use the organization name, rather than its UUID, in project creation permission errors.