### PR TITLE
scope store endpoints by project

### DIFF
--- a/exordos/manifests/core.yaml.j2
+++ b/exordos/manifests/core.yaml.j2
@@ -506,10 +506,6 @@ resources:
       uuid: "37ee8a65-ca05-54b2-a603-831511c01b3c"
       name: "repo.artifact.read"
       description: "List and read repository artifacts"
-    repo_store_element_read:
-      uuid: "f2be8c62-6675-4a3a-a24a-508ec976e97d"
-      name: "repo.store_element.read"
-      description: "List and read store elements"
 
   $core.iam.rolebinding:
     admin_role:
@@ -744,9 +740,7 @@ resources:
     binding_owner_repo_artifact_read:
       role: "$core.iam.roles.$owner:uuid"
       permission: "$core.iam.permissions.$repo_artifact_read:uuid"
-    binding_newcomer_repo_store_element_read:
-      role: "$core.iam.roles.$newcomer:uuid"
-      permission: "$core.iam.permissions.$repo_store_element_read:uuid"
+
   $core.vs.profiles:
     develop:
       name: "develop"

--- a/exordos_core/tests/functional/restapi/repo/test_repo_api.py
+++ b/exordos_core/tests/functional/restapi/repo/test_repo_api.py
@@ -23,8 +23,6 @@ from restalchemy.dm import filters as dm_filters
 from exordos_core.common import constants as c
 from exordos_core.repo.dm import models as repo_models
 
-STORE_ELEMENT_READ = "repo.store_element.read"
-
 
 class TestRepoElements:
     """REST API tests for repo elements endpoints."""
@@ -33,7 +31,12 @@ class TestRepoElements:
     REPO_REPOSITORIES_PATH = ["repo", "repositories"]
 
     def _create_repository(
-        self, user_api_client, auth, name="test-repo", driver_spec=None
+        self,
+        user_api_client,
+        auth,
+        name="test-repo",
+        driver_spec=None,
+        project_id=c.EM_PROJECT_ID,
     ):
         """Helper to create a repository with a simple driver spec."""
         client = user_api_client(auth)
@@ -44,7 +47,7 @@ class TestRepoElements:
             json={
                 "name": name,
                 "description": "Test repository",
-                "project_id": str(c.EM_PROJECT_ID),
+                "project_id": str(project_id),
                 "sync_mode": "lazy",
                 "driver_spec": driver_spec or {"kind": "database"},
             },
@@ -151,7 +154,9 @@ class TestRepoElements:
         assert not elements[0]["repository"].endswith(repo2["uuid"])
 
     def test_latest_stable_elements_route(self, user_api_client, auth_user_admin):
-        repo = self._create_repository(user_api_client, auth_user_admin)
+        repo = self._create_repository(
+            user_api_client, auth_user_admin, project_id=c.ZERO_UUID
+        )
         element_name = f"element-{sys_uuid.uuid4()}"
 
         old_element = self._create_element(
@@ -237,7 +242,9 @@ class TestRepoElements:
         assert len({element["name"] for element in elements}) == len(elements)
 
     def test_latest_stable_elements_pagination(self, user_api_client, auth_user_admin):
-        repo = self._create_repository(user_api_client, auth_user_admin)
+        repo = self._create_repository(
+            user_api_client, auth_user_admin, project_id=c.ZERO_UUID
+        )
         elements = [
             self._create_element(
                 user_api_client,
@@ -293,6 +300,7 @@ class TestRepoElements:
         auth_user_admin,
         auth_test1_p1_user,
         auth_test2_p1_user,
+        user_api_noauth_client,
     ):
         repo = self._create_repository(user_api_client, auth_user_admin)
         element_name = f"element-{sys_uuid.uuid4()}"
@@ -324,11 +332,7 @@ class TestRepoElements:
                     ),
                 )
 
-        client = user_api_client(
-            auth_test1_p1_user,
-            permissions=[STORE_ELEMENT_READ],
-            project_id=auth_test1_p1_user.project_id,
-        )
+        client = user_api_client(auth_test1_p1_user)
         store_url = client.build_collection_uri(
             ["repo", "store", "latest_stable_elements"]
         )
@@ -338,9 +342,24 @@ class TestRepoElements:
         assert elements["own"]["uuid"] in visible
         assert elements["other"]["uuid"] not in visible
 
+        # A caller without a project, an anonymous request included, reads
+        # the shared catalogue only.
+        admin_client = user_api_client(auth_user_admin)
+        elements_url = admin_client.build_collection_uri(["repo", "store", "elements"])
+        for unscoped_client in (admin_client, user_api_noauth_client()):
+            visible = {
+                element["uuid"] for element in unscoped_client.get(elements_url).json()
+            }
+
+            assert elements["admin"]["uuid"] in visible
+            assert elements["own"]["uuid"] not in visible
+            assert elements["other"]["uuid"] not in visible
+
     def test_element_stable_versions_action(self, user_api_client, auth_user_admin):
         client = user_api_client(auth_user_admin)
-        repo = self._create_repository(user_api_client, auth_user_admin)
+        repo = self._create_repository(
+            user_api_client, auth_user_admin, project_id=c.ZERO_UUID
+        )
         other_repo = self._create_repository(
             user_api_client,
             auth_user_admin,

--- a/exordos_core/user_api/repo/api/controllers.py
+++ b/exordos_core/user_api/repo/api/controllers.py
@@ -89,10 +89,7 @@ class RepositoryController(
 
 
 class StoreControllerMixin(iam_controllers.PolicyBasedWithoutProjectController):
-    """Policy and project scoping shared by the store endpoints."""
-
-    __policy_service_name__ = "repo"
-    __policy_name__ = "store_element"
+    """project scoping shared by the store endpoints."""
 
     def _project_filters(self):
         """Restrict a read to the projects the caller may see.
@@ -118,7 +115,6 @@ class LatestStableElementsController(
     )
 
     def filter(self, filters, **kwargs):
-        self._enforce("read")
         elements_by_name = {}
         elements = models.RepoElement.objects.get_all(
             filters={
@@ -165,9 +161,6 @@ class StoreProxyController(StoreControllerMixin, controllers.RoutesListControlle
     __TARGET_PATH__ = "/v1/repo/store/"
 
     def filter(self, filters, order_by=None):
-        # The policy controller's filter reaches for a resource model, and
-        # a route list has none, so list the routes explicitly.
-        self._enforce("read")
         return controllers.RoutesListController.filter(self, filters, order_by=order_by)
 
 
@@ -183,13 +176,19 @@ class StoreElementController(
     )
 
     def get(self, uuid, **kwargs):
-        # Scope the lookup so an action cannot reach another project.
         kwargs.update(self._project_filters())
-        return super().get(uuid=uuid, **kwargs)
+        return controllers.BaseResourceControllerPaginated.get(
+            self, uuid=uuid, **kwargs
+        )
+
+    def filter(self, filters, order_by=None):
+        filters.update(self._project_filters())
+        return controllers.BaseResourceControllerPaginated.filter(
+            self, filters, order_by=order_by
+        )
 
     @actions.get
     def stable_versions(self, resource: models.RepoElement):
-        self._enforce("read")
         elements = models.RepoElement.objects.get_all(
             filters={
                 "name": dm_filters.EQ(resource.name),

--- a/exordos_core/user_api/repo/api/controllers.py
+++ b/exordos_core/user_api/repo/api/controllers.py
@@ -95,11 +95,11 @@ class StoreControllerMixin(iam_controllers.PolicyBasedWithoutProjectController):
         """Restrict a read to the projects the caller may see.
 
         A project scoped caller reads the admin project, which holds the
-        shared catalogue, and their own. A token without a project is not
-        restricted, as elsewhere in the user API.
+        shared catalogue, and their own. A caller without a project, an
+        anonymous request included, reads the shared catalogue only.
         """
         if not self._ctx_project_id:
-            return {}
+            return {"project_id": dm_filters.EQ(c.ZERO_UUID)}
 
         return {"project_id": dm_filters.In([c.ZERO_UUID, self._ctx_project_id])}
 


### PR DESCRIPTION
## Summary by Sourcery

Scope repository store endpoints by project while preserving access to the shared catalogue.

Bug Fixes:
- Scope repository store element reads and related actions to the caller’s project and the shared catalogue, with unscoped and anonymous callers limited to the shared catalogue.

Enhancements:
- Remove the obsolete store-element read permission and role binding now that store access is enforced through project scoping.

Tests:
- Update repository API coverage for project-specific, shared-catalogue, and anonymous store element visibility.