### PR TITLE
Add manifest download actions

### DIFF
--- a/exordos_core/common/api/manifests.py
+++ b/exordos_core/common/api/manifests.py
@@ -1,0 +1,42 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import re
+import typing as tp
+
+import yaml
+
+CONTENT_TYPE_APPLICATION_YAML = "application/yaml"
+
+
+def download_response(
+    manifest: dict, name: str, version: str
+) -> tp.Tuple[bytes, int, dict]:
+    """Build a manifest YAML file response for a download action.
+
+    Controllers using it must pack the encoded body as is, see
+    `packers.JSONPackerPreEncoded`.
+    """
+    body = yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True)
+    filename = re.sub(r"[^A-Za-z0-9._-]", "_", f"{name}-{version}.yaml")
+    return (
+        body.encode(),
+        200,
+        {
+            "Content-Type": CONTENT_TYPE_APPLICATION_YAML,
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )

--- a/exordos_core/tests/functional/restapi/em/test_em.py
+++ b/exordos_core/tests/functional/restapi/em/test_em.py
@@ -71,6 +71,21 @@ class TestEmUserApi:
         assert response.status_code == 200
 
         url = client.build_resource_uri(
+            ["em", "manifests", manifest_uuid, "actions", "download"]
+        )
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response.headers["Content-Type"].startswith("application/yaml")
+        assert (
+            response.headers["Content-Disposition"]
+            == 'attachment; filename="core-0.0.1.yaml"'
+        )
+        downloaded = yaml.safe_load(response.text)
+        for key, value in manifest.items():
+            assert downloaded[key] == value
+        assert not {"uuid", "status", "project_id"} & set(downloaded)
+
+        url = client.build_resource_uri(
             ["em", "manifests", manifest_uuid, "actions", "install", "invoke"]
         )
         response = client.post(url)

--- a/exordos_core/tests/functional/restapi/repo/test_repo_api.py
+++ b/exordos_core/tests/functional/restapi/repo/test_repo_api.py
@@ -19,6 +19,7 @@ import uuid as sys_uuid
 from bazooka import exceptions as bazooka_exc
 import pytest
 from restalchemy.dm import filters as dm_filters
+import yaml
 
 from exordos_core.common import constants as c
 from exordos_core.repo.dm import models as repo_models
@@ -405,6 +406,28 @@ class TestRepoElements:
         assert [element["uuid"] for element in elements] == [
             other_stable_element["uuid"],
         ]
+
+    def test_store_element_download_action(self, user_api_client, auth_user_admin):
+        client = user_api_client(auth_user_admin)
+        repo = self._create_repository(user_api_client, auth_user_admin)
+        element = self._create_element(user_api_client, auth_user_admin, repo["uuid"])
+
+        action_url = client.build_resource_uri(
+            ["repo/store/elements", element["uuid"], "actions/download"]
+        )
+        response = client.get(action_url)
+
+        filename = f"{element['name']}-{element['version']}.yaml"
+        assert response.headers["Content-Type"].startswith("application/yaml")
+        assert (
+            response.headers["Content-Disposition"]
+            == f'attachment; filename="{filename}"'
+        )
+        assert yaml.safe_load(response.text) == {
+            "name": element["name"],
+            "version": element["version"],
+            "resources": {},
+        }
 
     # ------------------------------------------------------------------
     # DELETE tests

--- a/exordos_core/user_api/em/api/controllers.py
+++ b/exordos_core/user_api/em/api/controllers.py
@@ -21,6 +21,7 @@ from gcl_iam.api import controllers as iam_controllers
 from restalchemy.api import actions
 from restalchemy.api import constants
 from restalchemy.api import controllers
+from restalchemy.api import packers
 from restalchemy.api import resources
 from restalchemy.common import exceptions as ra_e
 from restalchemy.dm import filters as dm_filters
@@ -28,8 +29,20 @@ from restalchemy.openapi import constants as oa_c
 from restalchemy.openapi import utils
 import webob
 
+from exordos_core.common.api import manifests
 from exordos_core.elements.dm import models
 from exordos_core.vs.dm import models as vs_models
+
+
+# Fields the API keeps around the manifest document. The downloaded file is
+# the manifest as it was uploaded, so they are left out of it.
+MANIFEST_SERVICE_FIELDS = (
+    "uuid",
+    "status",
+    "project_id",
+    "created_at",
+    "updated_at",
+)
 
 
 class ElementHasNoProfileError(ra_e.ValidationErrorException):
@@ -75,6 +88,9 @@ class ManifestController(
 ):
     __policy_service_name__ = "em"
     __policy_name__ = "manifest"
+    # The download action returns an already encoded YAML body, everything
+    # else is packed as JSON.
+    __packer__ = packers.JSONPackerPreEncoded
     __resource__ = resources.ResourceByRAModel(
         model_class=models.Manifest,
         convert_underscore=False,
@@ -100,6 +116,14 @@ class ManifestController(
     @actions.get
     def validate(self, resource):
         return resource.validate_schema_base()
+
+    @actions.get
+    def download(self, resource):
+        return manifests.download_response(
+            resource.dump_to_simple_view(skip=MANIFEST_SERVICE_FIELDS),
+            resource.name,
+            resource.version,
+        )
 
 
 class ElementController(

--- a/exordos_core/user_api/em/api/routes.py
+++ b/exordos_core/user_api/em/api/routes.py
@@ -43,6 +43,12 @@ class ManifestValidateActionRoute(routes.Action):
     __controller__ = controllers.ManifestController
 
 
+class ManifestDownloadActionRoute(routes.Action):
+    """Handler for /v1/em/manifests/<uuid>/actions/download endpoint"""
+
+    __controller__ = controllers.ManifestController
+
+
 class SchemaRoute(routes.Route):
     """Handler for /v1/em/manifests/schema/ endpoint"""
 
@@ -61,6 +67,7 @@ class ManifestRoute(routes.Route):
     upgrade = routes.action(ManifestUpgradeActionRoute, invoke=True)
     uninstall = routes.action(ManifestUninstallActionRoute, invoke=True)
     validate = routes.action(ManifestValidateActionRoute, invoke=False)
+    download = routes.action(ManifestDownloadActionRoute, invoke=False)
     schema = routes.route(SchemaRoute)
 
 

--- a/exordos_core/user_api/repo/api/controllers.py
+++ b/exordos_core/user_api/repo/api/controllers.py
@@ -21,9 +21,11 @@ from restalchemy.api import actions
 from restalchemy.api import constants as ra_c
 from restalchemy.api import controllers
 from restalchemy.api import field_permissions as field_p
+from restalchemy.api import packers
 from restalchemy.api import resources
 from restalchemy.dm import filters as dm_filters
 
+from exordos_core.common.api import manifests
 from exordos_core.common import constants as c
 from exordos_core.common import exceptions as common_exc
 from exordos_core.repo.dm import models
@@ -175,6 +177,9 @@ class StoreElementController(
     StoreControllerMixin,
     controllers.BaseResourceControllerPaginated,
 ):
+    # The download action returns an already encoded YAML body, everything
+    # else is packed as JSON.
+    __packer__ = packers.JSONPackerPreEncoded
     __resource__ = resources.ResourceByRAModel(
         models.RepoElement,
         convert_underscore=False,
@@ -203,6 +208,19 @@ class StoreElementController(
             elements,
             key=lambda element: parse_version(element.version),
             reverse=True,
+        )
+
+    @actions.get
+    def download(self, resource: models.RepoElement):
+        self._enforce("read")
+
+        # A lazy repository keeps the manifest out of the catalogue until
+        # it is asked for.
+        if not resource.manifest:
+            resource.repository.actualize_element(resource)
+
+        return manifests.download_response(
+            resource.manifest, resource.name, resource.version
         )
 
 

--- a/exordos_core/user_api/repo/api/routes.py
+++ b/exordos_core/user_api/repo/api/routes.py
@@ -95,6 +95,12 @@ class StoreElementStableVersionsActionRoute(routes.Action):
     __controller__ = controllers.StoreElementController
 
 
+class StoreElementDownloadActionRoute(routes.Action):
+    """Handler for /v1/repo/store/elements/<uuid>/actions/download endpoint"""
+
+    __controller__ = controllers.StoreElementController
+
+
 class StoreElementRoute(routes.Route):
     """Handler for /v1/repo/store/elements/ endpoint"""
 
@@ -102,6 +108,7 @@ class StoreElementRoute(routes.Route):
     __allow_methods__ = [routes.GET, routes.FILTER]
 
     stable_versions = routes.action(StoreElementStableVersionsActionRoute, invoke=False)
+    download = routes.action(StoreElementDownloadActionRoute, invoke=False)
 
 
 class StoreRoute(routes.Route):


### PR DESCRIPTION
## Summary

Adds a `download` action that hands back a manifest as a YAML file, for both
installed manifests (EM) and catalogue elements (repo store). Until now the
manifest was only readable as part of a JSON resource, so getting the
original document back out meant reassembling it by hand.

## Changes

- `GET /v1/em/manifests/<uuid>/actions/download` returns the stored manifest
  as `application/yaml` with `Content-Disposition: attachment`. The fields the
  API keeps around the document (`uuid`, `status`, `project_id`, `created_at`,
  `updated_at`) are left out, so the file round-trips back through
  `POST /v1/em/manifests`.
- `GET /v1/repo/store/elements/<uuid>/actions/download` does the same for
  `RepoElement.manifest`. It enforces `repo.store_element.read` like
  `stable_versions`, and actualizes the element first when a lazy repository
  has not fetched the manifest yet — the check `RepoElementController.get`
  already makes.
- Both build the response through a shared helper in
  `exordos_core/common/api/manifests.py`; the filename is sanitized to
  `[A-Za-z0-9._-]` so an element name cannot break the header.
- Both controllers get `__packer__ = packers.JSONPackerPreEncoded` so the
  encoded YAML body passes through untouched while every other response stays
  JSON — the pattern `boot_api` already uses.

No new policy entries: `em.manifest.*` permissions do not exist and the other
manifest actions do not enforce, so `download` follows suit; the store action
reuses the existing `repo.store_element.read`. `ec-manifest-schema` produces
no change to `full_spec.yaml`.

## Verification

- `pytest exordos_core/tests/functional -n 10` — 534 passed, 3 skipped
- `pytest exordos_core/tests/unit -n 10` — 261 passed
- `ruff check` and `ruff format --check` on the touched files — clean
- `ec-manifest-schema` — `full_spec.yaml` unchanged

## Summary by Sourcery

Enable users to download installed and catalogue manifests as reusable YAML documents.

New Features:
- Add download actions for installed manifests and repository elements that return their manifests as downloadable YAML files.

Enhancements:
- Centralize YAML manifest response generation with sanitized filenames and appropriate download headers.
- Preserve JSON responses for existing controller actions while allowing pre-encoded YAML downloads.
- Actualize lazy repository elements before downloading their manifests and enforce repository read access.

Tests:
- Add functional coverage for manifest download content, headers, filenames, and omitted service metadata.
- Add functional coverage for repository element manifest downloads.