### PR TITLE
Match installed elements by manifest link

### DIFF
--- a/exordos_core/repo/agents/universal/drivers/repo_element.py
+++ b/exordos_core/repo/agents/universal/drivers/repo_element.py
@@ -192,9 +192,10 @@ class RepoEmBackendClient(client.DatabaseBackendClient):
         if upgrade_manifest:
             em_manifest.upgrade(session=session)
 
-        # Fetch installed EM element
+        # Fetch the EM element installed from this manifest. Matching by name
+        # alone is ambiguous when the same element exists in several projects.
         em_element = em_models.Element.objects.get_one_or_none(
-            filters={"name": ra_filters.EQ(to_install.name)},
+            filters={"manifest": ra_filters.EQ(em_manifest.uuid)},
             session=session,
         )
 
@@ -208,10 +209,8 @@ class RepoEmBackendClient(client.DatabaseBackendClient):
     ) -> tp.Collection[re_builder.InstalledManifest]:
         """List all installed elements for the given kind.
 
-        Collects installed repo elements and matches them against EM manifests
-        and elements by (name, version). Returns an InstalledManifest for
-        each EM manifest, enriched with repo element and EM element data
-        when available.
+        Returns an InstalledManifest for each EM manifest, enriched with the
+        EM element installed from that manifest when there is one.
         """
         if kind != KIND:
             raise ValueError(f"Unsupported kind {kind}")
@@ -221,19 +220,18 @@ class RepoEmBackendClient(client.DatabaseBackendClient):
         # that joins repo elements with EM manifests and elements in a single
         # query would be preferable. For now, we keep it simple with
         # individual queries.
-        em_manifests = {
-            (m.name, m.version): m
-            for m in em_models.Manifest.objects.get_all(session=session)
-        }
+        #
+        # Elements are matched by their manifest link rather than by
+        # (name, version): the same name and version may exist in several
+        # projects, and keying manifests that way hides all but one of them.
         em_elements = {
-            (e.name, e.version): e
+            e.manifest.uuid: e
             for e in em_models.Element.objects.get_all(session=session)
         }
 
-        # Match them by name and version
         installed = []
-        for key, em_manifest in em_manifests.items():
-            em_element = em_elements.get(key)
+        for em_manifest in em_models.Manifest.objects.get_all(session=session):
+            em_element = em_elements.get(em_manifest.uuid)
             installed.append(self._make_installed_manifest(em_manifest, em_element))
 
         return installed

--- a/exordos_core/tests/unit/repo/test_repo_element_driver.py
+++ b/exordos_core/tests/unit/repo/test_repo_element_driver.py
@@ -17,6 +17,8 @@
 from unittest import mock
 import uuid as sys_uuid
 
+import pytest
+
 from exordos_core.common import constants as c
 from exordos_core.repo.agents.universal.drivers import repo_element as driver
 from exordos_core.repo.builders import element as re_builder
@@ -232,6 +234,97 @@ class TestMakeEmManifest:
         assert result.exports == {}
         assert result.imports == {}
         assert result.openapi_spec is None
+
+
+class TestList:
+    """Tests for RepoEmBackendClient._list."""
+
+    def _make_client(self):
+        storage = mock.MagicMock()
+        return driver.RepoEmBackendClient(tf_storage=storage)
+
+    def _make_em_manifest(self, name="core", version="1.0.0", project_id=c.ZERO_UUID):
+        em_manifest = mock.MagicMock()
+        em_manifest.uuid = sys_uuid.uuid4()
+        em_manifest.name = name
+        em_manifest.version = version
+        em_manifest.description = "Test manifest"
+        em_manifest.project_id = project_id
+        em_manifest.api_version = "v1"
+        em_manifest.schema_version = 1
+        em_manifest.openapi_spec = None
+        em_manifest.exports = {}
+        em_manifest.imports = {}
+        em_manifest.requirements = {}
+        em_manifest.resources = {}
+        return em_manifest
+
+    def _make_em_element(self, em_manifest):
+        em_element = mock.MagicMock()
+        em_element.uuid = sys_uuid.uuid4()
+        em_element.name = em_manifest.name
+        em_element.version = em_manifest.version
+        em_element.manifest = em_manifest
+        return em_element
+
+    def _list(self, client, em_manifests, em_elements):
+        with (
+            mock.patch.object(
+                driver.em_models.Manifest, "objects", new=mock.MagicMock()
+            ) as manifest_objects,
+            mock.patch.object(
+                driver.em_models.Element, "objects", new=mock.MagicMock()
+            ) as element_objects,
+        ):
+            manifest_objects.get_all.return_value = em_manifests
+            element_objects.get_all.return_value = em_elements
+            return client._list(None, driver.KIND)
+
+    def test_unsupported_kind(self):
+        """Should reject a kind the driver does not serve."""
+        client = self._make_client()
+
+        with pytest.raises(ValueError):
+            client._list(None, "some_other_kind")
+
+    def test_same_name_and_version_in_several_projects(self):
+        """Should return every manifest sharing a name and version."""
+        client = self._make_client()
+        first = self._make_em_manifest(
+            name="dbaas", version="2.4.0", project_id=c.ZERO_UUID
+        )
+        second = self._make_em_manifest(
+            name="dbaas",
+            version="2.4.0",
+            project_id=sys_uuid.uuid4(),
+        )
+
+        result = self._list(client, [first, second], [])
+
+        assert {i.uuid for i in result} == {first.uuid, second.uuid}
+
+    def test_element_matched_by_manifest_link(self):
+        """Should attach the element to the manifest it was installed from."""
+        client = self._make_client()
+        installed = self._make_em_manifest(name="dbaas", version="2.4.0")
+        other = self._make_em_manifest(name="dbaas", version="2.4.0")
+        em_element = self._make_em_element(installed)
+
+        result = self._list(client, [installed, other], [em_element])
+
+        by_uuid = {i.uuid: i for i in result}
+        assert by_uuid[installed.uuid].element == em_element.uuid
+        assert by_uuid[other.uuid].element is None
+
+    def test_manifest_without_element(self):
+        """Should return manifests that have no installed element."""
+        client = self._make_client()
+        em_manifest = self._make_em_manifest()
+
+        result = self._list(client, [em_manifest], [])
+
+        assert len(result) == 1
+        assert result[0].element is None
 
 
 class TestRepoElementCapabilityDriver:


### PR DESCRIPTION
## Summary

`RepoEmBackendClient._list` keyed EM manifests by `(name, version)`, so
manifests sharing a name and version were collapsed to one and the rest never
reached the universal agent. On a live installation this hid a `dbaas 2.4.0`
manifest belonging to a second project: it is tracked in the agent's
target-fields storage but absent from every `list()` result, so drift on it is
never detected. Which of the two won the collapse followed Postgres row order,
so it could flip between polls.

Elements are now matched to manifests by their manifest link, which
`Manifest.install()` sets and `Manifest.upgrade()` keeps current, and which
`Manifest.uninstall()` already joins on.

## Changes

- `_list` iterates manifests directly instead of building a
  `{(name, version): manifest}` dict, so every manifest row is returned
- `_list` indexes elements by `element.manifest.uuid` rather than
  `(name, version)`
- `_update` looks up the element by manifest link instead of by name alone,
  so it and `_list` agree on which element a manifest installed; matching by
  name is ambiguous when the same element name exists in several projects
- Unit tests for the cross-project case, element-to-manifest matching, and
  manifests with no installed element

## Verification

- `pytest exordos_core/tests/unit` - 265 passed
- `ruff check` and `ruff format --check` on both touched files - clean
- `mypy exordos_core/repo/agents/universal/drivers/repo_element.py` - unchanged
  from baseline (the one finding is a pre-existing untyped `**kwargs` on
  `_list`, confirmed against a stash of the change)
- Functional tests not run
- The new `_list` tests fail against the previous implementation, which
  returned one manifest where two were expected

## Summary by Sourcery

Match installed elements by manifest link so all project-specific manifests remain visible and accurately tracked.

Bug Fixes:
- Preserve and report every installed manifest when multiple projects use the same name and version.
- Associate installed elements with their originating manifest to prevent ambiguous cross-project matches.

Tests:
- Add coverage for duplicate manifests, manifest-linked element matching, and manifests without installed elements.