### PR TITLE
build(deps): move to RESTAlchemy 16

### DIFF
--- a/exordos_core/boot_api/dm/models.py
+++ b/exordos_core/boot_api/dm/models.py
@@ -45,16 +45,26 @@ class MachineNetboot(models.Machine):
         self.set_netboot_params(gc_host, gc_boot_api, kernel, initrd)
 
     @classmethod
-    def restore_from_storage(
+    def restore_row(
         cls,
-        gc_host: str = LOCAL_GC_HOST,
-        gc_boot_api: str = LOCAL_GC_BOOT_API,
-        kernel: tp.Optional[str] = None,
-        initrd: tp.Optional[str] = None,
-        **kwargs,
-    ):
-        obj = super().restore_from_storage(**kwargs)
-        obj.set_netboot_params(gc_host, gc_boot_api, kernel, initrd)
+        row: tp.Mapping[str, tp.Any],
+        pour: tp.Any = None,
+    ) -> "MachineNetboot":
+        # Every read arrives here -- one model, and a page of them alike;
+        # `restore_from_storage`, which this class used to override, is
+        # only one of the two, and a collection does not go by it.
+        #
+        # The netboot parameters are not columns of the machine table, so
+        # they are never in a row: a restored machine gets the defaults
+        # here, and the controller overwrites them with what the
+        # installation is configured with.
+        obj = super().restore_row(row, pour)
+        obj.set_netboot_params(
+            LOCAL_GC_HOST,
+            LOCAL_GC_BOOT_API,
+            None,
+            None,
+        )
         return obj
 
     def set_netboot_params(

--- a/exordos_core/tests/unit/boot_api/test_models.py
+++ b/exordos_core/tests/unit/boot_api/test_models.py
@@ -1,0 +1,59 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import uuid as sys_uuid
+
+from gcl_sdk.agents.universal.drivers import pool as ua_pool
+
+from exordos_core.boot_api.dm import models
+from exordos_core.common import constants as c
+
+
+def _row():
+    uuid = sys_uuid.uuid4()
+    return {
+        "uuid": uuid,
+        "firmware_uuid": uuid,
+        "name": "machine",
+        "description": "",
+        "cores": 1,
+        "ram": 1024,
+        "boot": ua_pool.BootAlternative.network.value,
+        "status": "ACTIVE",
+        "project_id": c.ZERO_UUID,
+        "machine_type": "VM",
+        "image": None,
+        "node": None,
+        "pool": None,
+    }
+
+
+class TestMachineNetbootRestore:
+    def test_a_row_read_one_at_a_time_carries_netboot_params(self):
+        netboot = models.MachineNetboot.restore_from_storage(**_row())
+
+        assert netboot.gc_host == models.LOCAL_GC_HOST
+        assert netboot.kernel.startswith("tftp://")
+
+    def test_a_row_read_as_part_of_a_page_carries_them_too(self):
+        # A collection does not go through `restore_from_storage`: both
+        # reads meet the model at `restore_row`, and before RESTAlchemy 16
+        # the page left these unset.
+        netboot = models.MachineNetboot.restore_row(_row())
+
+        assert netboot.gc_host == models.LOCAL_GC_HOST
+        assert netboot.gc_boot_api == models.LOCAL_GC_BOOT_API
+        assert netboot.kernel.startswith("tftp://")
+        assert netboot.initrd.startswith("tftp://")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,15 @@ dependencies = [
     "bjoern>=3.2.2",  # BSD License (BSD-3-Clause)
     "gcl_looper>=1.2.3,<2.0.0",  # Apache-2.0
     # The floor is the version the committed OpenAPI specs are generated
-    # with. 15.3.0 emits component `$ref`s where 15.2.x inlined the same
-    # schemas, so a lower floor means whoever regenerates decides what the
+    # with, so a lower floor means whoever regenerates decides what the
     # spec looks like, and the diff is tens of thousands of lines either way.
-    "restalchemy>=15.3.0,<16.0.0",  # Apache-2.0
+    "restalchemy>=16.0.1,<17.0.0",  # Apache-2.0
     "Authlib>=1.3.2,<2.0.0",  # BSD License (BSD-3-Clause)
     "bazooka>=1.3.0,<2.0.0",  # Apache-2.0
     "Jinja2>=3.1.5,<4.0.0",  # BSD License (BSD-3-Clause)
     "izulu>=0.50.0,<1.0.0",  # MIT License
-    "gcl_iam>=1.3.2,<2.0.0",  # Apache-2.0
-    "gcl_sdk[libvirt]>=3.4.0,<4.0.0",  # Apache-2.0
+    "gcl_iam>=1.4.0,<2.0.0",  # Apache-2.0
+    "gcl_sdk[libvirt]>=3.5.0,<4.0.0",  # Apache-2.0
     "gcl_certbot_plugin>=0.0.12,<1.0.0",  # Apache-2.0
     "pyotp>=2.9.0,<3.0.0",  # MIT License
     "pyyaml>=6.0.0,<7.0.0",  # MIT

--- a/uv.lock
+++ b/uv.lock
@@ -734,9 +734,9 @@ requires-dist = [
     { name = "dnspython", marker = "extra == 'test'", specifier = ">=2.6.0,<3.0.0" },
     { name = "firebase-admin", specifier = ">=6.0.0,<8.0.0" },
     { name = "gcl-certbot-plugin", specifier = ">=0.0.12,<1.0.0" },
-    { name = "gcl-iam", specifier = ">=1.3.2,<2.0.0" },
+    { name = "gcl-iam", specifier = ">=1.4.0,<2.0.0" },
     { name = "gcl-looper", specifier = ">=1.2.3,<2.0.0" },
-    { name = "gcl-sdk", extras = ["libvirt"], specifier = ">=3.4.0,<4.0.0" },
+    { name = "gcl-sdk", extras = ["libvirt"], specifier = ">=3.5.0,<4.0.0" },
     { name = "izulu", specifier = ">=0.50.0,<1.0.0" },
     { name = "jinja2", specifier = ">=3.1.5,<4.0.0" },
     { name = "mkdocs-glightbox", marker = "extra == 'docs'" },
@@ -754,7 +754,7 @@ requires-dist = [
     { name = "pytest-timer", marker = "extra == 'test'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pytest-xdist", extras = ["psutil"], marker = "extra == 'test'", specifier = ">=3.6.1,<4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0.0" },
-    { name = "restalchemy", specifier = ">=15.3.0,<16.0.0" },
+    { name = "restalchemy", specifier = ">=16.0.1,<17.0.0" },
     { name = "ruamel-yaml", marker = "extra == 'docs'", specifier = "==0.19.1" },
     { name = "ruamel-yaml", marker = "extra == 'test'", specifier = "==0.19.1" },
     { name = "ruff", marker = "extra == 'ruff'" },
@@ -809,7 +809,7 @@ wheels = [
 
 [[package]]
 name = "gcl-iam"
-version = "1.3.2"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bazooka" },
@@ -818,9 +818,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "restalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/7a/fcba2b3b54472f2af412dbb8adcd18c1abd294a591fe4339a80f3db51ffb/gcl_iam-1.3.2.tar.gz", hash = "sha256:0b440ea1e6e098d8174c978927ee45df550eefa8f6dfe0ea2a3327193e81799b", size = 122904, upload-time = "2026-07-13T13:27:36.868Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/7b/bb547b0d5e8609985828a8e4a700e7e2608ddef8218f5fe5e4bf2e1975dc/gcl_iam-1.4.0.tar.gz", hash = "sha256:7888e63b295ae1e54f6a43b22f51dbeeb0b69f2c155895d556c68873af1eb2e7", size = 162913, upload-time = "2026-09-02T08:39:00.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/7e/a9aae671a42b9598914b94f720c25cf6d69758a49377dec2f8f45c1e1671/gcl_iam-1.3.2-py3-none-any.whl", hash = "sha256:9b0d13e676771931918a457cea3754c6767cc065ce848e2e7ebecae07b6fe11a", size = 40784, upload-time = "2026-07-13T13:27:35.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6a/da9cd26debbe3ef5e7b777dee55646bee95143a4f14820e8a21d978681f3/gcl_iam-1.4.0-py3-none-any.whl", hash = "sha256:89b9b86ed00a4b13998205943315c777d15a07015337e070e3456490e3ddec58", size = 93258, upload-time = "2026-09-02T08:38:59.339Z" },
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "gcl-sdk"
-version = "3.4.0"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bjoern" },
@@ -853,9 +853,9 @@ dependencies = [
     { name = "restalchemy" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/66/c85932ea470abbbb62d05ad43bd8fb2b4c4673e3fe17329c07fb566a590b/gcl_sdk-3.4.0.tar.gz", hash = "sha256:eb630fd7e586136e56be1493c7448ab4b254b343641f37a12160e8a7f5d59832", size = 357287, upload-time = "2026-09-01T12:18:26.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/82/065d5ea10d15c4cbbf7977c271fb13936d976eb147f0a339044ca18d19a3/gcl_sdk-3.5.0.tar.gz", hash = "sha256:667b986318e7eb14b459ab2d8fd9aff479997d1af42bb05c1afa9c23e3498daa", size = 358425, upload-time = "2026-09-02T10:50:39.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/44/37d5e05e45f5ed6f5b28a62cd364303ffd615aa97b49fe86157ac8ac5876/gcl_sdk-3.4.0-py3-none-any.whl", hash = "sha256:6b47e5df36c13d10765c12ba0341a2337cbcd2ddec06e34b881cd75b352cbb9f", size = 309191, upload-time = "2026-09-01T12:18:24.641Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c9/548ec4bad546232a10f43784de6ea04b85a54aff50f6e3b6d241a6b74222/gcl_sdk-3.5.0-py3-none-any.whl", hash = "sha256:d53517561478c57298d6f04914fe45a3c75a78ab61f2ea5515ac03660cc1da68", size = 310895, upload-time = "2026-09-02T10:50:38.089Z" },
 ]
 
 [package.optional-dependencies]
@@ -2583,7 +2583,7 @@ wheels = [
 
 [[package]]
 name = "restalchemy"
-version = "15.3.0"
+version = "16.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "email-validator" },
@@ -2596,9 +2596,9 @@ dependencies = [
     { name = "requests" },
     { name = "webob" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/0a/fb50d392111b8415798582939f1923585f204ca7ab103fbc9367cacbbc6f/restalchemy-15.3.0.tar.gz", hash = "sha256:22b0d31d91009aacc72c291374bbe274022a784cee04ce5382bf75ca27f10e99", size = 560802, upload-time = "2026-08-07T14:17:39.43Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/ee/8ee5e064bfee5b278f83c901b0f22681475ec2171baa512b8c8a341b6f3c/restalchemy-16.0.2.tar.gz", hash = "sha256:4b3aa1841b09d191f9fe462689387335476f3fda4fb98a6a915204a05b80dd72", size = 633533, upload-time = "2026-09-01T15:12:08.685Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/47/6beac6b129ba5f52b35bb3c225081b46dd7fde092f249f0dbb07e1c15d21/restalchemy-15.3.0-py3-none-any.whl", hash = "sha256:27ff0d7928724c5a7da11ef079d37819e4d48ca125969453e82d2ce23a2df703", size = 618596, upload-time = "2026-08-07T14:17:37.629Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e6/a61773bc788dfd0f534d5f935e655472781d25d55b7aed1b4714a8452871/restalchemy-16.0.2-py3-none-any.whl", hash = "sha256:515ebf45bb2920d264395436cd31d278f55e82b0c99615c5fb6d6e99a484c6d7", size = 674213, upload-time = "2026-09-01T15:12:06.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The release train is complete: gcl_iam 1.4.0 and gcl_sdk 3.5.0 are the first releases carrying RESTAlchemy 16, and below them the constraints have no solution, so both floors rise with it. `uv.lock` is regenerated now that all three are published; it resolves restalchemy 16.0.2, whose only change over the floor is an opt-in `defer_release` on `savepoint()` that nothing here passes.

One breaking change of 16.0.0 lands here. `MachineNetboot` overrode `restore_from_storage`, which a page of rows no longer goes by: `get_all()` would have returned netboot machines with their netboot parameters unset -- an `AttributeError` on the first read of `gc_host` -- while reading one by uuid kept working. The override moves to `restore_row`, where both ways of reading a row arrive, and a unit test holds each of the two. The netboot parameters are not columns of the machine table, so a row never carries them: the defaults are what a restored machine gets, and the controller overwrites them with the installation's configuration, exactly as before.

Nothing else meets the release: no naive `UTCDateTime` is declared, no model overrides a row restore elsewhere, no test asserts on generated SQL, and no `__new__`-built model is written to. What a UTC timestamp is written as did not change, so no stored resource re-reconciles on the upgrade. The floor is 16.0.1, not 16.0.0: that release asks a permissions container what it says about every field at once and drops `meets_field_permission`, which nothing here writes -- `HiddenFieldMap` is RA's and keeps its interface, and `FieldsIamPermissions` answers `resolve` from gcl_iam 1.4.0 on.

The four committed OpenAPI documents regenerate byte-identical. Unit (267) and functional (540 passed, 3 skipped) suites pass against a clean database.

## Summary by Sourcery

Upgrade the project’s dependency stack to RESTAlchemy 16 while preserving netboot machine restoration across all read paths.

Bug Fixes:
- Ensure netboot parameters are initialized when MachineNetboot instances are restored from collection reads as well as individual reads.

Build:
- Raise the minimum RESTAlchemy version to 16.0.1 and update gcl_iam and gcl_sdk dependency floors to 1.4.0 and 3.5.0.

Tests:
- Add unit coverage for MachineNetboot restoration through individual and paginated row reads.

Chores:
- Regenerate the dependency lockfile for the updated release floors.