### PR TITLE
Reduce memory usage of the repo proxy general service

### DIFF
--- a/exordos_core/repo/agents/universal/drivers/repo_element.py
+++ b/exordos_core/repo/agents/universal/drivers/repo_element.py
@@ -17,6 +17,7 @@
 import logging
 import os
 import typing as tp
+import uuid as sys_uuid
 
 from gcl_sdk.agents.universal.clients.backend import db as client
 from gcl_sdk.agents.universal.clients.backend import exceptions as backend_exc
@@ -60,7 +61,7 @@ class RepoEmBackendClient(client.DatabaseBackendClient):
     def _make_installed_manifest(
         self,
         em_manifest: em_models.Manifest,
-        em_element: em_models.Element | None,
+        em_element_uuid: sys_uuid.UUID | None,
     ) -> re_builder.InstalledManifest:
         """Build an InstalledManifest from an EM manifest and its counterparts.
 
@@ -80,7 +81,7 @@ class RepoEmBackendClient(client.DatabaseBackendClient):
             name=em_manifest.name,
             version=em_manifest.version,
             description=em_manifest.description,
-            element=em_element.uuid if em_element is not None else None,
+            element=em_element_uuid,
             status=models.RepoElementStatus.ACTIVE.value,
             project_id=em_manifest.project_id,
         )
@@ -221,20 +222,25 @@ class RepoEmBackendClient(client.DatabaseBackendClient):
         # that joins repo elements with EM manifests and elements in a single
         # query would be preferable. For now, we keep it simple with
         # individual queries.
+
+        # Only the UUID of an element is needed here. Keeping just the UUIDs
+        # lets the fetched Element objects (each of which prefetches its whole
+        # manifest and profile) be released before the manifests are read.
+        em_element_uuids = {
+            (e.name, e.version): e.uuid
+            for e in em_models.Element.objects.get_all(session=session)
+        }
         em_manifests = {
             (m.name, m.version): m
             for m in em_models.Manifest.objects.get_all(session=session)
-        }
-        em_elements = {
-            (e.name, e.version): e
-            for e in em_models.Element.objects.get_all(session=session)
         }
 
         # Match them by name and version
         installed = []
         for key, em_manifest in em_manifests.items():
-            em_element = em_elements.get(key)
-            installed.append(self._make_installed_manifest(em_manifest, em_element))
+            installed.append(
+                self._make_installed_manifest(em_manifest, em_element_uuids.get(key))
+            )
 
         return installed
 

--- a/exordos_core/repo/builders/repository.py
+++ b/exordos_core/repo/builders/repository.py
@@ -22,6 +22,7 @@ from gcl_looper.services.oslo import base as oslo_base
 from gcl_sdk.agents.universal.dm import models as ua_models
 from gcl_sdk.agents.universal.services import builder as sdk_builder
 from packaging import version as packaging_version
+from restalchemy.dm import filters as ra_filters
 
 from exordos_core.repo.dm import models
 
@@ -113,9 +114,11 @@ class RepoProxyBuilderService(
 
     def _refresh_repository(self, instance: models.Repository) -> None:
         """Actualize elements in the repository."""
-        # Get existing elements for this repository
-        existing_elements = {
-            (elem.name, elem.version): elem
+        # Get existing elements for this repository. Only the UUIDs are kept:
+        # the full records carry the manifest, specification and inventory
+        # dicts, and are needed only for the few elements to be deleted below.
+        existing_uuids = {
+            (elem.name, elem.version): elem.uuid
             for elem in models.RepoElement.objects.get_all(
                 filters={"repository": instance.uuid},
             )
@@ -125,9 +128,12 @@ class RepoProxyBuilderService(
         inventory_elements = {
             (e.name, e.version): e for e in instance.iter_elements_in_inventory()
         }
+        inventory_keys = frozenset(inventory_elements)
         new_elements_count = 0
-        for key in inventory_elements.keys() - existing_elements.keys():
-            element = inventory_elements[key]
+        for key in inventory_keys - existing_uuids.keys():
+            # Drop the element from the mapping once handled: in COPY mode it
+            # holds the full downloaded manifest, specification and inventory.
+            element = inventory_elements.pop(key)
 
             # In COPY mode, actualize element to download full data
             if instance.sync_mode == models.SyncMode.COPY:
@@ -147,8 +153,10 @@ class RepoProxyBuilderService(
         # Remove old elements that are no longer in inventory,
         # but keep installed ones
         deleted_elements_count = 0
-        for key in existing_elements.keys() - inventory_elements.keys():
-            element = existing_elements[key]
+        for key in existing_uuids.keys() - inventory_keys:
+            element = models.RepoElement.objects.get_one(
+                filters={"uuid": ra_filters.EQ(existing_uuids[key])},
+            )
 
             # Skip deletion if element is installed
             if (

--- a/exordos_core/tests/unit/repo/test_repo_element_driver.py
+++ b/exordos_core/tests/unit/repo/test_repo_element_driver.py
@@ -70,7 +70,7 @@ class TestMakeInstalledManifest:
         em_manifest = self._make_em_manifest()
         em_element = self._make_em_element()
 
-        result = client._make_installed_manifest(em_manifest, em_element)
+        result = client._make_installed_manifest(em_manifest, em_element.uuid)
 
         assert result.uuid == em_manifest.uuid
         assert result.name == em_manifest.name
@@ -114,7 +114,7 @@ class TestMakeInstalledManifest:
         em_manifest = self._make_em_manifest()
         em_element = self._make_em_element()
 
-        result = client._make_installed_manifest(em_manifest, em_element)
+        result = client._make_installed_manifest(em_manifest, em_element.uuid)
 
         assert result.uuid == em_manifest.uuid
         assert result.element == em_element.uuid
@@ -158,7 +158,7 @@ class TestMakeInstalledManifest:
         em_manifest.openapi_spec = {"paths": {}}
         em_element = self._make_em_element()
 
-        result = client._make_installed_manifest(em_manifest, em_element)
+        result = client._make_installed_manifest(em_manifest, em_element.uuid)
 
         assert result.manifest["exports"] == {"exp1": {}}
         assert result.manifest["imports"] == {"imp1": {}}


### PR DESCRIPTION
## Summary

The repo proxy general service (`exordos-repo-proxy-gservice`) held full ORM
records alive in paths that only ever read a UUID off them, so its peak
footprint scaled with manifest payload size instead of element count. This
trims the retention in the two hot paths without changing behaviour.

The remaining ~75 MiB is import-time cost (`launchpad`, `restalchemy`,
`gcl_sdk`, `elements.dm.models`), shared by all three services the launchpad
hosts and not reducible without dropping dependencies.

## Changes

- `RepoEmBackendClient._list` runs on every agent iteration (`iter_min_period=3`)
  and loaded every EM `Manifest` *and* every EM `Element`, holding both while
  building the result. `Element.manifest` and `Element.profile` are declared
  `prefetch=True`, which restalchemy compiles into a JOIN, so each element
  dragged in a second full copy of `requirements`, `resources`, `exports`,
  `imports` and `openapi_spec` — all to read `em_element.uuid`. The element
  query now yields a `(name, version) -> uuid` map and runs first, so those
  objects are released before the manifests are read.
- `_make_installed_manifest` takes the element UUID rather than the model.
  Manifest dedup by `(name, version)` is kept deliberately: `em_manifests` has
  no unique constraint on that pair, unlike `em_elements`.
- `_refresh_repository` keyed every element of a repository by its full record;
  those carry the `manifest`, `specification` and `inventory` dicts and are
  needed only for the few elements being deleted, which are now re-fetched in a
  single `ra_filters.In` query.
- `_refresh_repository` also materialised the `iter_elements_in_inventory`
  generator and kept every entry. In COPY mode `actualize_element` downloads the
  full payload into each one, so all of them accumulated for the whole refresh;
  entries are now dropped from the mapping as they are saved.

What this does and does not change: `get_all()` still materialises every full
record for the length of that call, and there is no way around that with the
ORM as it stands — both `ObjectCollection._get_all` and `_query` end in
`restore_from_storage(**params)`, with no column projection available. What
goes away is the *concurrent* retention: the full-record maps used to stay
alive across the inventory loop, where in COPY mode `actualize_element` builds
a second full payload set on top of them, so peak was roughly 2x the element
set; it is now ~1x, the transient `get_all` spike.

Measured on a stand-in with 300 elements and realistically sized manifests, the
`_list` element mapping retains 13.92 MiB before and 0.07 MiB after. That figure
is the retained map, not the transient peak. The stand-in omits profiles, so the
real saving is somewhat larger.

Not addressed: the `NOTE(akremenetsky)` in `_list` proposes a joined view to
replace the separate manifest/element queries, which would also cut the
remaining manifest materialisation. That needs a migration and is left alone
here.

## Changes to tests

Three unit tests passed a mock element object into `_make_installed_manifest`;
they now pass `.uuid`.

## Verification

- `ruff check .` — clean
- `pytest exordos_core/tests/unit -n 10` — 265 passed
- `pytest exordos_core/tests/functional -n 10` — 540 passed, 3 skipped
  (includes `test_refresh_repository_removes_old_elements`,
  `..._keeps_installed_elements`, `..._updates_latest`, and both COPY and LAZY
  iteration modes)
- `mypy` — no new errors; diffed against the base, the one pre-existing
  `_list(**kwargs)` annotation error just shifts a line

## Summary by Sourcery

Reduce peak memory usage in repository synchronization paths without changing repository behavior.

Enhancements:
- Reduce repository proxy memory retention by storing only element UUIDs during manifest and repository refresh operations.
- Release downloaded inventory elements as they are processed and re-fetch only stale records needed for deletion.

Tests:
- Update unit tests for UUID-based installed manifest construction.
