### PR TITLE
reduce telemetry memory usage

### DIFF
--- a/exordos_core/telemetry/service.py
+++ b/exordos_core/telemetry/service.py
@@ -101,10 +101,18 @@ class TelemetryService(basic.BasicService):
 
     @staticmethod
     def _collect_compute_nodes(data):
-        nodes = compute_models.Node.objects.get_all()
-        data["nodes_count"] = len(nodes)
-        data["nodes_total_cores"] = sum(n.cores for n in nodes)
-        data["nodes_total_ram"] = sum(n.ram for n in nodes)
+        # `nodes` is the largest table on a stand, so aggregate in SQL instead
+        # of materializing every row just to sum two columns.
+        session = contexts.Context().get_session()
+        row = session.execute(
+            "SELECT COUNT(uuid) AS nodes_count,"
+            " COALESCE(SUM(cores), 0) AS nodes_total_cores,"
+            " COALESCE(SUM(ram), 0) AS nodes_total_ram"
+            f" FROM {compute_models.Node.__tablename__}",
+        ).fetchone()
+        data["nodes_count"] = row["nodes_count"]
+        data["nodes_total_cores"] = row["nodes_total_cores"]
+        data["nodes_total_ram"] = row["nodes_total_ram"]
 
     @staticmethod
     def _collect_machine_pools(data):

--- a/exordos_core/tests/functional/service/test_telemetry.py
+++ b/exordos_core/tests/functional/service/test_telemetry.py
@@ -1,0 +1,44 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.common import contexts
+
+from exordos_core.compute.dm import models as compute_models
+from exordos_core.telemetry import service
+
+
+class TestCollectComputeNodes:
+    def test_aggregates_match_row_sums(self, default_node) -> None:
+        data = {}
+        with contexts.Context().session_manager():
+            service.TelemetryService._collect_compute_nodes(data)
+            nodes = compute_models.Node.objects.get_all()
+
+        assert data["nodes_count"] == len(nodes)
+        assert data["nodes_total_cores"] == sum(n.cores for n in nodes)
+        assert data["nodes_total_ram"] == sum(n.ram for n in nodes)
+
+    def test_aggregates_on_empty_table(self, user_api) -> None:
+        data = {}
+        with contexts.Context().session_manager():
+            service.TelemetryService._collect_compute_nodes(data)
+
+        # COALESCE keeps the sums numeric when there are no rows at all.
+        assert data == {
+            "nodes_count": 0,
+            "nodes_total_cores": 0,
+            "nodes_total_ram": 0,
+        }


### PR DESCRIPTION
## Summary by Sourcery

Aggregate compute-node telemetry in the database to reduce memory usage while preserving correct results for populated and empty tables.

Enhancements:
- Reduce telemetry memory usage by aggregating compute-node counts and resources directly in the database instead of loading all nodes.
- Add functional coverage for compute-node aggregation with populated and empty tables.

Tests:
- Add functional tests validating compute-node aggregate values and empty-table defaults.