### PR TITLE
Add value store permissions and guard VS actions

### DIFF
--- a/exordos/manifests/core.yaml.j2
+++ b/exordos/manifests/core.yaml.j2
@@ -510,6 +510,66 @@ resources:
       uuid: "37ee8a65-ca05-54b2-a603-831511c01b3c"
       name: "repo.artifact.read"
       description: "List and read repository artifacts"
+    vs_profile_activate:
+      uuid: "019108e8-9b47-410a-8114-74a55d75b722"
+      name: "vs.profile.activate"
+      description: "Activate value store profiles"
+    vs_profile_create:
+      uuid: "98fc4753-4b7c-4cec-984b-3c6a72b58552"
+      name: "vs.profile.create"
+      description: "Create value store profiles"
+    vs_profile_delete:
+      uuid: "bb58d8e0-ba55-4d94-b675-3052388bc17d"
+      name: "vs.profile.delete"
+      description: "Delete value store profiles"
+    vs_profile_read:
+      uuid: "a63f8d40-33c7-4cfe-be85-ab56b7066f10"
+      name: "vs.profile.read"
+      description: "List and read value store profiles"
+    vs_profile_update:
+      uuid: "bee0ccab-c775-4db5-9162-599f5dcdd5c3"
+      name: "vs.profile.update"
+      description: "Update value store profiles"
+    vs_value_create:
+      uuid: "5a242b13-3e32-47fd-bf40-02e88c7223aa"
+      name: "vs.value.create"
+      description: "Create value store values"
+    vs_value_delete:
+      uuid: "35ce11fd-d165-457a-89c7-ec8095399a5d"
+      name: "vs.value.delete"
+      description: "Delete value store values"
+    vs_value_read:
+      uuid: "25c622e8-7bad-4cb5-87c7-dcaa332b0ebc"
+      name: "vs.value.read"
+      description: "List and read value store values"
+    vs_value_update:
+      uuid: "824d38dd-b936-46c0-a451-6476c1745373"
+      name: "vs.value.update"
+      description: "Update value store values"
+    vs_variable_create:
+      uuid: "126a2ad2-ed32-44ca-a81c-c5942b4cd041"
+      name: "vs.variable.create"
+      description: "Create value store variables"
+    vs_variable_delete:
+      uuid: "5b5d0ec6-6de5-4744-8961-bc57cf8101a6"
+      name: "vs.variable.delete"
+      description: "Delete value store variables"
+    vs_variable_read:
+      uuid: "f3c11f09-233a-4242-bf25-0d7c9fa8d35d"
+      name: "vs.variable.read"
+      description: "List and read value store variables"
+    vs_variable_release_value:
+      uuid: "e27e7f79-2aa9-4825-8cb6-694dcc9ac35b"
+      name: "vs.variable.release_value"
+      description: "Release the selected value of value store variables"
+    vs_variable_select_value:
+      uuid: "fa16fabf-20e4-4c7b-a4cc-3cc1689eb7c1"
+      name: "vs.variable.select_value"
+      description: "Select a value for value store variables"
+    vs_variable_update:
+      uuid: "176241b7-0919-4663-85b5-ab47c4bad351"
+      name: "vs.variable.update"
+      description: "Update value store variables"
 
   $core.iam.rolebinding:
     admin_role:
@@ -748,6 +808,24 @@ resources:
     binding_owner_repo_artifact_read:
       role: "$core.iam.roles.$owner:uuid"
       permission: "$core.iam.permissions.$repo_artifact_read:uuid"
+    binding_owner_vs_profile_activate:
+      role: "$core.iam.roles.$owner:uuid"
+      permission: "$core.iam.permissions.$vs_profile_activate:uuid"
+    binding_owner_vs_profile_read:
+      role: "$core.iam.roles.$owner:uuid"
+      permission: "$core.iam.permissions.$vs_profile_read:uuid"
+    binding_owner_vs_value_read:
+      role: "$core.iam.roles.$owner:uuid"
+      permission: "$core.iam.permissions.$vs_value_read:uuid"
+    binding_owner_vs_variable_read:
+      role: "$core.iam.roles.$owner:uuid"
+      permission: "$core.iam.permissions.$vs_variable_read:uuid"
+    binding_owner_vs_variable_release_value:
+      role: "$core.iam.roles.$owner:uuid"
+      permission: "$core.iam.permissions.$vs_variable_release_value:uuid"
+    binding_owner_vs_variable_select_value:
+      role: "$core.iam.roles.$owner:uuid"
+      permission: "$core.iam.permissions.$vs_variable_select_value:uuid"
 
   $core.vs.profiles:
     develop:

--- a/exordos_core/elements/dm/models.py
+++ b/exordos_core/elements/dm/models.py
@@ -31,6 +31,7 @@ from restalchemy.dm import properties
 from restalchemy.dm import relationships
 from restalchemy.dm import types as ra_types
 from restalchemy.dm import types_dynamic as ra_types_dyn
+from restalchemy.storage.sql import engines
 from restalchemy.storage.sql import orm
 
 from exordos_core.common import exceptions
@@ -973,6 +974,30 @@ class Export(
     @property
     def full_link(self) -> str:
         return f"${self.element.name}.{self.link}"
+
+    @classmethod
+    def exported_resource_uuids(cls, session: tp.Any = None) -> tp.Set[sys_uuid.UUID]:
+        """Return the uuids of the resources published through exports.
+
+        An export names its resource by link and a resource builds that
+        link from its prefix and its name, so the two are joined on it.
+        The uuid of a resource is the uuid of the entity it manages, which
+        is what callers outside the element model look the export up by.
+        """
+        expression = (
+            f"SELECT res.uuid FROM {Resource.__tablename__} res"
+            f" JOIN {cls.__tablename__} exp ON exp.element = res.element"
+            " AND exp.link = res.resource_link_prefix || '.$' || res.name;"
+        )
+
+        if session:
+            curs = session.execute(expression, tuple())
+            return {row["uuid"] for row in curs.fetchall()}
+
+        engine = engines.engine_factory.get_engine()
+        with engine.session_manager() as session:
+            curs = session.execute(expression, tuple())
+            return {row["uuid"] for row in curs.fetchall()}
 
 
 class ImportEnum(str, enum.Enum):

--- a/exordos_core/tests/functional/restapi/vs/test_user_api.py
+++ b/exordos_core/tests/functional/restapi/vs/test_user_api.py
@@ -471,3 +471,246 @@ class TestVSUserApi:
 
         with pytest.raises(bazooka_exc.NotFoundError):
             client.get(url)
+
+    @staticmethod
+    def _export_variable(user_api, variable: tp.Dict[str, tp.Any]) -> None:
+        """Publish a variable through an element export, as a manifest does."""
+        element = sys_uuid.uuid4()
+        link_prefix = "$core.vs.variables"
+        with user_api.engine.session_manager() as session:
+            session.execute(
+                "INSERT INTO em_elements (uuid, name, version) VALUES (%s, %s, %s)",
+                (element, f"element-{element}", "0.0.1"),
+            )
+            session.execute(
+                "INSERT INTO em_resources"
+                " (uuid, name, element, resource_link_prefix)"
+                " VALUES (%s, %s, %s, %s)",
+                (
+                    sys_uuid.UUID(variable["uuid"]),
+                    variable["name"],
+                    element,
+                    link_prefix,
+                ),
+            )
+            session.execute(
+                "INSERT INTO em_exports (uuid, element, name, link)"
+                " VALUES (%s, %s, %s, %s)",
+                (
+                    sys_uuid.uuid4(),
+                    element,
+                    variable["name"],
+                    f"{link_prefix}.${variable['name']}",
+                ),
+            )
+
+    def test_profiles_read_only_global_and_own(
+        self,
+        user_api_client: iam_clients.GenesisCoreTestRESTClient,
+        auth_user_admin: iam_clients.GenesisCoreAuth,
+        auth_test1_p1_user: iam_clients.GenesisCoreAuth,
+        auth_test2_p1_user: iam_clients.GenesisCoreAuth,
+    ):
+        admin_client = user_api_client(auth_user_admin)
+        url = admin_client.build_collection_uri(["vs", "profiles"])
+        profiles = {}
+        for label, payload in (
+            ("global", self._profile_factory(profile_type="GLOBAL")),
+            (
+                "own",
+                self._profile_factory(
+                    profile_type="ELEMENT",
+                    project_id=auth_test1_p1_user.project_id,
+                ),
+            ),
+            (
+                "other",
+                self._profile_factory(
+                    profile_type="ELEMENT",
+                    project_id=auth_test2_p1_user.project_id,
+                ),
+            ),
+        ):
+            response = admin_client.post(url, json=payload)
+            assert response.status_code == 201
+            profiles[label] = payload
+
+        client = user_api_client(
+            auth_test1_p1_user,
+            permissions=["vs.profile.read"],
+            project_id=auth_test1_p1_user.project_id,
+        )
+        visible = {profile["uuid"] for profile in client.get(url).json()}
+
+        assert profiles["global"]["uuid"] in visible
+        assert profiles["own"]["uuid"] in visible
+        assert profiles["other"]["uuid"] not in visible
+
+        with pytest.raises(bazooka_exc.NotFoundError):
+            client.get(
+                client.build_resource_uri(["vs", "profiles", profiles["other"]["uuid"]])
+            )
+
+    def test_profiles_write_only_own(
+        self,
+        user_api_client: iam_clients.GenesisCoreTestRESTClient,
+        auth_user_admin: iam_clients.GenesisCoreAuth,
+        auth_test1_p1_user: iam_clients.GenesisCoreAuth,
+        auth_test2_p1_user: iam_clients.GenesisCoreAuth,
+    ):
+        admin_client = user_api_client(auth_user_admin)
+        url = admin_client.build_collection_uri(["vs", "profiles"])
+        global_profile = self._profile_factory(profile_type="GLOBAL")
+        other_profile = self._profile_factory(
+            profile_type="ELEMENT",
+            project_id=auth_test2_p1_user.project_id,
+        )
+        for payload in (global_profile, other_profile):
+            assert admin_client.post(url, json=payload).status_code == 201
+
+        client = user_api_client(
+            auth_test1_p1_user,
+            permissions=[
+                "vs.profile.create",
+                "vs.profile.read",
+                "vs.profile.update",
+                "vs.profile.delete",
+            ],
+            project_id=auth_test1_p1_user.project_id,
+        )
+
+        # A profile is created in the caller's own project, whatever the
+        # body asks for.
+        own_profile = self._profile_factory(
+            profile_type="ELEMENT",
+            project_id=auth_test1_p1_user.project_id,
+        )
+        response = client.post(url, json=own_profile)
+        assert response.status_code == 201
+        assert response.json()["project_id"] == str(auth_test1_p1_user.project_id)
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            client.post(url, json=self._profile_factory(profile_type="ELEMENT"))
+
+        own_url = client.build_resource_uri(["vs", "profiles", own_profile["uuid"]])
+        response = client.put(own_url, json={"description": "mine"})
+        assert response.status_code == 200
+
+        # A profile another project owns is not writable, the global one
+        # the caller reads included.
+        for profile in (global_profile, other_profile):
+            profile_url = client.build_resource_uri(["vs", "profiles", profile["uuid"]])
+            with pytest.raises(bazooka_exc.NotFoundError):
+                client.put(profile_url, json={"description": "theirs"})
+            with pytest.raises(bazooka_exc.NotFoundError):
+                client.delete(profile_url)
+
+        assert client.delete(own_url).status_code == 204
+
+    def test_variables_read_only_exported_and_own(
+        self,
+        user_api,
+        user_api_client: iam_clients.GenesisCoreTestRESTClient,
+        auth_user_admin: iam_clients.GenesisCoreAuth,
+        auth_test1_p1_user: iam_clients.GenesisCoreAuth,
+        auth_test2_p1_user: iam_clients.GenesisCoreAuth,
+    ):
+        admin_client = user_api_client(auth_user_admin)
+        url = admin_client.build_collection_uri(["vs", "variables"])
+        variables = {}
+        for label, project_id in (
+            ("exported", c.EM_PROJECT_ID),
+            ("own", auth_test1_p1_user.project_id),
+            ("other", auth_test2_p1_user.project_id),
+        ):
+            payload = self._variable_factory(project_id=project_id)
+            response = admin_client.post(url, json=payload)
+            assert response.status_code == 201
+            variables[label] = payload
+
+        self._export_variable(user_api, variables["exported"])
+
+        client = user_api_client(
+            auth_test1_p1_user,
+            permissions=["vs.variable.read"],
+            project_id=auth_test1_p1_user.project_id,
+        )
+        visible = {variable["uuid"] for variable in client.get(url).json()}
+
+        assert variables["exported"]["uuid"] in visible
+        assert variables["own"]["uuid"] in visible
+        assert variables["other"]["uuid"] not in visible
+
+        with pytest.raises(bazooka_exc.NotFoundError):
+            client.get(
+                client.build_resource_uri(
+                    ["vs", "variables", variables["other"]["uuid"]]
+                )
+            )
+
+    def test_variables_write_only_own(
+        self,
+        user_api,
+        user_api_client: iam_clients.GenesisCoreTestRESTClient,
+        auth_user_admin: iam_clients.GenesisCoreAuth,
+        auth_test1_p1_user: iam_clients.GenesisCoreAuth,
+        auth_test2_p1_user: iam_clients.GenesisCoreAuth,
+    ):
+        admin_client = user_api_client(auth_user_admin)
+        url = admin_client.build_collection_uri(["vs", "variables"])
+        exported = self._variable_factory(project_id=c.EM_PROJECT_ID)
+        other = self._variable_factory(project_id=auth_test2_p1_user.project_id)
+        for payload in (exported, other):
+            assert admin_client.post(url, json=payload).status_code == 201
+        self._export_variable(user_api, exported)
+
+        client = user_api_client(
+            auth_test1_p1_user,
+            permissions=[
+                "vs.variable.create",
+                "vs.variable.read",
+                "vs.variable.update",
+                "vs.variable.delete",
+                "vs.variable.release_value",
+            ],
+            project_id=auth_test1_p1_user.project_id,
+        )
+
+        own = self._variable_factory(project_id=auth_test1_p1_user.project_id)
+        response = client.post(url, json=own)
+        assert response.status_code == 201
+        assert response.json()["project_id"] == str(auth_test1_p1_user.project_id)
+
+        with pytest.raises(bazooka_exc.ForbiddenError):
+            client.post(
+                url,
+                json=self._variable_factory(project_id=auth_test2_p1_user.project_id),
+            )
+
+        own_url = client.build_resource_uri(["vs", "variables", own["uuid"]])
+        assert client.put(own_url, json={"description": "mine"}).status_code == 200
+
+        # A variable another project owns is not writable, the exported one
+        # the caller reads included.
+        for variable in (exported, other):
+            variable_url = client.build_resource_uri(
+                ["vs", "variables", variable["uuid"]]
+            )
+            release_url = client.build_resource_uri(
+                [
+                    "vs",
+                    "variables",
+                    variable["uuid"],
+                    "actions",
+                    "release_value",
+                    "invoke",
+                ]
+            )
+            with pytest.raises(bazooka_exc.NotFoundError):
+                client.put(variable_url, json={"description": "theirs"})
+            with pytest.raises(bazooka_exc.NotFoundError):
+                client.post(release_url, json={})
+            with pytest.raises(bazooka_exc.NotFoundError):
+                client.delete(variable_url)
+
+        assert client.delete(own_url).status_code == 204

--- a/exordos_core/user_api/vs/api/controllers.py
+++ b/exordos_core/user_api/vs/api/controllers.py
@@ -41,7 +41,7 @@ class ValuesStoreController(controllers.RoutesListController):
 
 
 class ProfilesController(
-    iam_controllers.PolicyBasedController,
+    iam_controllers.PolicyBasedWithoutProjectController,
     controllers.BaseResourceControllerPaginated,
 ):
     """Controller for /v1/vs/profiles/ endpoint"""
@@ -69,7 +69,7 @@ class ProfilesController(
 
 
 class VariablesController(
-    iam_controllers.PolicyBasedController,
+    iam_controllers.PolicyBasedWithoutProjectController,
     controllers.BaseResourceControllerPaginated,
 ):
     """Controller for /v1/vs/variables/ endpoint"""

--- a/exordos_core/user_api/vs/api/controllers.py
+++ b/exordos_core/user_api/vs/api/controllers.py
@@ -25,6 +25,7 @@ from restalchemy.api import resources
 from restalchemy.common import exceptions as ra_e
 from restalchemy.dm import filters as dm_filters
 
+from exordos_core.elements.dm import models as em_models
 from exordos_core.vs.dm import models as models
 
 
@@ -40,10 +41,68 @@ class ValuesStoreController(controllers.RoutesListController):
     __TARGET_PATH__ = "/v1/vs/"
 
 
-class ProfilesController(
+class ProjectScopedController(
     iam_controllers.PolicyBasedWithoutProjectController,
     controllers.BaseResourceControllerPaginated,
 ):
+    """A controller over entities a project shares with the others.
+
+    A read reaches the shared entities and the caller's own ones, a write
+    only the caller's own: an entity is shared because the project holding
+    it publishes it, and publishing something is not handing it over. A
+    caller without a project, an admin token included, is not narrowed.
+    """
+
+    def _shared(self):
+        """Return the clause selecting the entities every project reads."""
+        raise NotImplementedError()
+
+    def _readable(self, filters):
+        if not self._ctx_project_id:
+            return filters
+
+        return dm_filters.AND(
+            filters,
+            dm_filters.OR(
+                self._shared(),
+                {"project_id": dm_filters.EQ(self._ctx_project_id)},
+            ),
+        )
+
+    def _enforce_own(self, uuid):
+        """Refuse a write to an entity another project owns."""
+        if not self._ctx_project_id:
+            return
+
+        self.model.objects.get_one(
+            filters={
+                "uuid": dm_filters.EQ(uuid),
+                "project_id": dm_filters.EQ(self._ctx_project_id),
+            },
+        )
+
+    def create(self, **kwargs):
+        self._enforce_and_override_project_id_in_kwargs("create", kwargs)
+        return super().create(**kwargs)
+
+    def get(self, uuid, **kwargs):
+        self._enforce("read")
+        filters = dict(kwargs, uuid=dm_filters.EQ(uuid))
+        return self.model.objects.get_one(filters=self._readable(filters))
+
+    def filter(self, filters, order_by=None):
+        return super().filter(self._readable(filters), order_by=order_by)
+
+    def update(self, uuid, **kwargs):
+        self._enforce_own(uuid)
+        return super().update(uuid, **kwargs)
+
+    def delete(self, uuid):
+        self._enforce_own(uuid)
+        return super().delete(uuid)
+
+
+class ProfilesController(ProjectScopedController):
     """Controller for /v1/vs/profiles/ endpoint"""
 
     __policy_name__ = "profile"
@@ -61,6 +120,10 @@ class ProfilesController(
         ),
     )
 
+    def _shared(self):
+        """A global profile is read by every project."""
+        return {"profile_type": dm_filters.EQ(infra_c.ProfileType.GLOBAL.value)}
+
     @actions.post
     def activate(self, resource: models.Profile):
         self._enforce("activate")
@@ -68,10 +131,7 @@ class ProfilesController(
         return resource
 
 
-class VariablesController(
-    iam_controllers.PolicyBasedWithoutProjectController,
-    controllers.BaseResourceControllerPaginated,
-):
+class VariablesController(ProjectScopedController):
     """Controller for /v1/vs/variables/ endpoint"""
 
     __policy_name__ = "variable"
@@ -91,6 +151,11 @@ class VariablesController(
         ),
     )
 
+    def _shared(self):
+        """A variable an element publishes through its manifest exports."""
+        exported = em_models.Export.exported_resource_uuids()
+        return {"uuid": dm_filters.In(list(exported))}
+
     def update(self, uuid, **kwargs):
         kwargs["status"] = infra_c.VariableStatus.IN_PROGRESS.value
         return super().update(uuid, **kwargs)
@@ -98,6 +163,7 @@ class VariablesController(
     @actions.post
     def select_value(self, resource: models.Variable, value: str):
         self._enforce("select_value")
+        self._enforce_own(resource.uuid)
         value = models.Value.objects.get_one(
             filters={"uuid": dm_filters.EQ(value)},
         )
@@ -113,6 +179,7 @@ class VariablesController(
     @actions.post
     def release_value(self, resource: models.Variable):
         self._enforce("release_value")
+        self._enforce_own(resource.uuid)
         if resource.selected_value is None:
             raise NoValueSelectedError()
         resource.release_value()

--- a/exordos_core/user_api/vs/api/controllers.py
+++ b/exordos_core/user_api/vs/api/controllers.py
@@ -63,6 +63,7 @@ class ProfilesController(
 
     @actions.post
     def activate(self, resource: models.Profile):
+        self._enforce("activate")
         resource.activate()
         return resource
 
@@ -96,6 +97,7 @@ class VariablesController(
 
     @actions.post
     def select_value(self, resource: models.Variable, value: str):
+        self._enforce("select_value")
         value = models.Value.objects.get_one(
             filters={"uuid": dm_filters.EQ(value)},
         )
@@ -110,6 +112,7 @@ class VariablesController(
 
     @actions.post
     def release_value(self, resource: models.Variable):
+        self._enforce("release_value")
         if resource.selected_value is None:
             raise NoValueSelectedError()
         resource.release_value()


### PR DESCRIPTION
## Summary

The value store (`/v1/vs/`) had no IAM permissions in the core manifest, and its
three custom actions were not enforced at all — any authenticated caller who
could reach the endpoint could invoke them. This adds the missing permissions,
enforces the actions in the controllers, and grants project owners what they
need to use them.

## Changes

- Add `vs.{profile,value,variable}.{create,delete,read,update}` permissions to
  `$core.iam.permissions` in the core manifest.
- Enforce the custom actions in `exordos_core/user_api/vs/api/controllers.py`:
  `activate` on profiles, `select_value` and `release_value` on variables —
  matching how compute and repo controllers guard their actions.
- Add `vs.profile.activate`, `vs.variable.select_value` and
  `vs.variable.release_value` permissions for those actions.
- Bind the action permissions to the `owner` role, together with
  `vs.profile.read`, `vs.variable.read` and `vs.value.read`: invoking an action
  goes through `get_resource_by_uuid()` → `controller.get()`, which enforces
  `read`, and `vs.value.read` lets an owner list values to pick one for
  `select_value`.

Note: the CRUD permissions (create/update/delete) are intentionally left
unbound, reachable only through the admin `*.*.*` binding, following the
precedent set by the `secret.*` permissions.

## Verification

- `pytest exordos_core/tests/unit -n 10` — 271 passed
- `pytest exordos_core/tests/functional -n 10` — 542 passed, 3 skipped
- `ruff check` / `ruff format --check` on the changed controller — clean
- Manual API check against a non-admin owner token: n/a

## Summary by Sourcery

Secure value-store APIs with comprehensive IAM permissions and project-aware resource and action authorization.

New Features:
- Add value-store permissions for profile, value, and variable CRUD operations and custom actions.
- Grant project owners the read and action permissions required to use shared value-store resources.

Bug Fixes:
- Enforce IAM permissions for profile activation and variable value selection or release actions.
- Restrict value-store reads to global, exported, or project-owned resources and writes to project-owned resources.

Enhancements:
- Add project-scoped value-store controller behavior with correctly scoped pagination and exported-variable visibility.

Tests:
- Add functional coverage for value-store visibility, ownership, CRUD access, action authorization, and scoped pagination.