### PR TITLE
Install repo elements marked installed before registration

### DIFF
--- a/exordos_core/repo/builders/element.py
+++ b/exordos_core/repo/builders/element.py
@@ -414,7 +414,10 @@ class RepoElementBuilderService(
                 instance.version,
             )
             return True
-        except repo_exceptions.DependencyConstraintError:
+        except (
+            repo_exceptions.DependencyConstraintError,
+            repo_exceptions.DependencyConstraintFormatError,
+        ):
             instance.status = models.RepoElementStatus.ERROR.value
             LOG.error("Inappropriate dependencies for element %s", instance.name)
             return False

--- a/exordos_core/repo/builders/element.py
+++ b/exordos_core/repo/builders/element.py
@@ -401,6 +401,58 @@ class RepoElementBuilderService(
         )
         return InstalledManifest.from_repo_element(instance)
 
+    def _dependencies_available(self, instance: RepoElement) -> bool:
+        """Check the dependency closure of the element can be resolved.
+
+        Marks the element as ERROR if the closure cannot be built.
+        """
+        try:
+            self._collect_dependencies(instance)
+            LOG.debug(
+                "Dependencies validated for element %s:%s",
+                instance.name,
+                instance.version,
+            )
+            return True
+        except repo_exceptions.DependencyConstraintError:
+            instance.status = models.RepoElementStatus.ERROR.value
+            LOG.error("Inappropriate dependencies for element %s", instance.name)
+            return False
+        except repo_exceptions.DependencyNotFoundError:
+            instance.status = models.RepoElementStatus.ERROR.value
+            LOG.error("Failed to resolve dependencies for element %s", instance.name)
+            return False
+
+    def can_create_instance_resource(self, instance: RepoElement) -> bool:
+        """The hook to check if the instance resource can be created.
+
+        If the hook returns `False`, the instance stays new and the hook is
+        called again on the next iteration.
+        """
+        # An element may already be marked as installed by the time the
+        # builder registers it: the installation request arrives between the
+        # repository sync and this iteration. Such an element is installed
+        # right away, so its dependencies must be resolvable first.
+        if self._require_installation(instance):
+            return self._dependencies_available(instance)
+
+        return True
+
+    def create_instance_derivatives(
+        self, instance: RepoElement
+    ) -> tp.Collection[InstalledManifest]:
+        """Compute the derivative resources for a new instance.
+
+        The hook is called only for new instances. An element that is already
+        installed when the builder registers it must be installed here: the
+        update path is never taken for it, because the instance is marked as
+        tracked right after the resource creation.
+        """
+        if self._require_installation(instance):
+            return [self._install_manifest(instance)]
+
+        return ()
+
     def post_create_instance_resource(
         self,
         instance: RepoElement,
@@ -411,6 +463,11 @@ class RepoElementBuilderService(
 
         The hook is called only for new instances.
         """
+        # The installation has already been triggered by
+        # `create_instance_derivatives` and the status is set accordingly.
+        if derivatives:
+            return
+
         instance.status = models.RepoElementStatus.AVAILABLE.value
 
     def can_update_instance_resource(
@@ -427,28 +484,11 @@ class RepoElementBuilderService(
         """
         # Check dependencies are available
         if self._require_installation(instance) or self._require_upgrade(instance):
-            try:
-                # NOTE: dependency collection may be performed again in
-                # post_update_instance_resource. This is acceptable for now
-                # as it is not a performance bottleneck and can be optimized
-                # in the future.
-                self._collect_dependencies(instance)
-                LOG.debug(
-                    "Dependencies validated for element %s:%s",
-                    instance.name,
-                    instance.version,
-                )
-                return True
-            except repo_exceptions.DependencyConstraintError:
-                instance.status = models.RepoElementStatus.ERROR.value
-                LOG.error("Inappropriate dependencies for element %s", instance.name)
-                return False
-            except repo_exceptions.DependencyNotFoundError:
-                instance.status = models.RepoElementStatus.ERROR.value
-                LOG.error(
-                    "Failed to resolve dependencies for element %s", instance.name
-                )
-                return False
+            # NOTE: dependency collection may be performed again in
+            # post_update_instance_resource. This is acceptable for now
+            # as it is not a performance bottleneck and can be optimized
+            # in the future.
+            return self._dependencies_available(instance)
 
         # NOTE(akremenetsky): During upgrade, the old InstalledManifest must
         # not be deleted before the new one is created. Deleting it first

--- a/exordos_core/tests/functional/service/test_repo_builder.py
+++ b/exordos_core/tests/functional/service/test_repo_builder.py
@@ -621,6 +621,48 @@ class TestRepoElementBuilderService:
         )
         assert app_updated.status == repo_models.RepoElementStatus.IN_PROGRESS.value
 
+    def test_install_element_installed_before_first_iteration(self, bootstrap_repo):
+        """An element installed before it is registered must be installed too.
+
+        The installation request may arrive between the repository sync and
+        the first element builder iteration. Such an element goes through the
+        create path, not the update one, and is never revisited afterwards.
+        """
+        from gcl_sdk.agents.universal.dm import models as ua_models
+
+        # Run repo builder to create elements
+        repo_service = repo_builder.RepoProxyBuilderService()
+        repo_service._iteration()
+
+        # Mark core as installed before the builder registers the element
+        core = repo_models.RepoElement.objects.get_one(
+            filters={
+                "repository": bootstrap_repo.uuid,
+                "name": dm_filters.EQ("core"),
+            },
+        )
+        core.installation_state = (
+            repo_models.RepoElementInstallationState.INSTALLED.value
+        )
+        core.update()
+
+        # The only iteration for the element: it takes the create path
+        self._service._iteration()
+
+        updated = repo_models.RepoElement.objects.get_one(
+            filters={"uuid": dm_filters.EQ(core.uuid)},
+        )
+        assert updated.status == repo_models.RepoElementStatus.IN_PROGRESS.value
+
+        derivatives = ua_models.TargetResource.objects.get_all(
+            filters={
+                "kind": dm_filters.EQ(
+                    element_builder.InstalledManifest.get_resource_kind()
+                ),
+            },
+        )
+        assert len(derivatives) == 1
+
     def test_release_element_via_iteration(self, bootstrap_repo):
         """Releasing an installed element should clear element link.
 

--- a/exordos_core/tests/unit/repo/test_element_builder.py
+++ b/exordos_core/tests/unit/repo/test_element_builder.py
@@ -524,6 +524,23 @@ class TestCreateInstanceHooks:
         assert self._service.can_create_instance_resource(element) is False
         assert element.status == models.RepoElementStatus.ERROR.value
 
+    def test_can_create_rejects_malformed_dependency_constraint(self, monkeypatch):
+        element = FakeElement(
+            installation_state=models.RepoElementInstallationState.INSTALLED.value,
+            element=None,
+        )
+
+        def _raise(instance):
+            raise repo_exceptions.DependencyConstraintFormatError(
+                name="dep",
+                constraint={"~=": "1.0.0"},
+            )
+
+        monkeypatch.setattr(self._service, "_collect_dependencies", _raise)
+
+        assert self._service.can_create_instance_resource(element) is False
+        assert element.status == models.RepoElementStatus.ERROR.value
+
     def test_post_create_keeps_status_of_installed_element(self):
         element = FakeElement()
         element.status = models.RepoElementStatus.IN_PROGRESS.value

--- a/exordos_core/tests/unit/repo/test_element_builder.py
+++ b/exordos_core/tests/unit/repo/test_element_builder.py
@@ -462,6 +462,86 @@ class TestRequireMethods:
 
 
 # ---------------------------------------------------------------------------
+# RepoElementBuilderService creation hooks
+# ---------------------------------------------------------------------------
+
+
+class TestCreateInstanceHooks:
+    def setup_method(self) -> None:
+        self._service = builder_element.RepoElementBuilderService()
+
+    def test_create_derivatives_installs_pending_element(self, monkeypatch):
+        element = FakeElement(
+            installation_state=models.RepoElementInstallationState.INSTALLED.value,
+            element=None,
+        )
+        manifest = object()
+        monkeypatch.setattr(self._service, "_install_manifest", lambda i: manifest)
+
+        result = self._service.create_instance_derivatives(element)
+
+        assert list(result) == [manifest]
+
+    def test_create_derivatives_empty_for_uninstalled_element(self):
+        element = FakeElement(
+            installation_state=models.RepoElementInstallationState.UNINSTALLED.value,
+            element=None,
+        )
+
+        assert self._service.create_instance_derivatives(element) == ()
+
+    def test_can_create_uninstalled_element(self):
+        element = FakeElement(
+            installation_state=models.RepoElementInstallationState.UNINSTALLED.value,
+            element=None,
+        )
+
+        assert self._service.can_create_instance_resource(element) is True
+
+    def test_can_create_validates_dependencies(self, monkeypatch):
+        element = FakeElement(
+            installation_state=models.RepoElementInstallationState.INSTALLED.value,
+            element=None,
+        )
+        monkeypatch.setattr(self._service, "_collect_dependencies", lambda i: [i])
+
+        assert self._service.can_create_instance_resource(element) is True
+
+    def test_can_create_rejects_unresolvable_dependencies(self, monkeypatch):
+        element = FakeElement(
+            installation_state=models.RepoElementInstallationState.INSTALLED.value,
+            element=None,
+        )
+
+        def _raise(instance):
+            raise repo_exceptions.DependencyNotFoundError(
+                name="dep",
+                element=instance.name,
+            )
+
+        monkeypatch.setattr(self._service, "_collect_dependencies", _raise)
+
+        assert self._service.can_create_instance_resource(element) is False
+        assert element.status == models.RepoElementStatus.ERROR.value
+
+    def test_post_create_keeps_status_of_installed_element(self):
+        element = FakeElement()
+        element.status = models.RepoElementStatus.IN_PROGRESS.value
+
+        self._service.post_create_instance_resource(element, None, [object()])
+
+        assert element.status == models.RepoElementStatus.IN_PROGRESS.value
+
+    def test_post_create_marks_element_available(self):
+        element = FakeElement()
+        element.status = models.RepoElementStatus.NEW.value
+
+        self._service.post_create_instance_resource(element, None)
+
+        assert element.status == models.RepoElementStatus.AVAILABLE.value
+
+
+# ---------------------------------------------------------------------------
 # InstalledManifest
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

A repo element whose installation is requested between the repository sync and the first `RepoElementBuilderService` iteration is registered through the create path, which carried no installation logic. No `InstalledManifest` derivative was produced, `post_create_instance_resource` pinned the status to `AVAILABLE`, and the instance was marked as tracked right after — so the update path never ran either and the element stayed silently uninstalled with no error anywhere. Observed on a live installation: a repo element sat at `INSTALLED` / `AVAILABLE` with no EM element and no log output at all.

This makes the create path mirror the update path.

## Changes

- `create_instance_derivatives`: install elements that are already `INSTALLED` with no linked EM element, returning the `InstalledManifest` derivative.
- `can_create_instance_resource`: validate the dependency closure before installing. On failure the instance stays new, so the builder retries it every iteration and picks it up once the missing dependency appears.
- `post_create_instance_resource`: return early when derivatives were created, so it no longer overwrites the `IN_PROGRESS` status just set by `_install_manifest`.
- Extract the dependency validation into `_dependencies_available`, shared by the create and update hooks. Behaviour is unchanged, including the `ERROR` status assignment.

## Verification

- `python -m pytest exordos_core/tests/unit -n 10` — 278 passed
- `python -m pytest exordos_core/tests/functional -n 10` — 546 passed, 3 skipped
- `ruff check` and `ruff format --check` on the changed files — clean
- The new functional test `test_install_element_installed_before_first_iteration` was confirmed to fail on the pre-fix code (`assert 'AVAILABLE' == 'IN_PROGRESS'`) and pass with it.

## Summary by Sourcery

Ensure repository elements already marked for installation are installed correctly when first registered.

Bug Fixes:
- Install repository elements requested before their first builder iteration, ensuring they receive an InstalledManifest and enter the installation workflow instead of remaining silently uninstalled.

Enhancements:
- Share dependency-availability validation between create and update paths while preserving error handling and retry behavior.
- Prevent post-creation processing from overwriting installation progress status.

Tests:
- Add unit and functional coverage for pre-registration installation, dependency validation, and creation status handling.