### PR TITLE
ci(build): pass connection URI to hypervisor init

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           PREFETCH_PID=$!
 
           EXORDOS_BIN=$(which exordos)
-          sudo $EXORDOS_BIN compute hypervisors init
+          sudo $EXORDOS_BIN compute hypervisors init --connection-uri qemu+tcp://10.20.0.1/system
 
           wait $PREFETCH_PID || { cat prefetch.log; exit 1; }
           cat prefetch.log


### PR DESCRIPTION
Initialize the compute hypervisor with an explicit `qemu+tcp://10.20.0.1/system` connection URI instead of relying on the default local libvirt socket.

## Summary by Sourcery

Build:
- Configure the CI hypervisor initialization to use the explicit remote QEMU connection URI.