### PR TITLE
perf(repo): reduce iter_min_period to 1 second

### DIFF
--- a/exordos_core/repo/builders/repository.py
+++ b/exordos_core/repo/builders/repository.py
@@ -43,7 +43,7 @@ class RepoProxyBuilderService(
 ):
     def __init__(
         self,
-        iter_min_period: int = 3,
+        iter_min_period: int = 1,
         iter_pause: float = 0.1,
     ) -> None:
         super().__init__(


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Reduce the repository proxy builder’s default iteration minimum period from three seconds to one second.