### PR TITLE
Install upgrade targets marked installed before registration

### DIFF
--- a/exordos_core/repo/builders/element.py
+++ b/exordos_core/repo/builders/element.py
@@ -433,10 +433,10 @@ class RepoElementBuilderService(
         called again on the next iteration.
         """
         # An element may already be marked as installed by the time the
-        # builder registers it: the installation request arrives between the
-        # repository sync and this iteration. Such an element is installed
-        # right away, so its dependencies must be resolvable first.
-        if self._require_installation(instance):
+        # builder registers it: the installation or upgrade request arrives
+        # between the repository sync and this iteration. Such an element is
+        # installed right away, so its dependencies must be resolvable first.
+        if self._require_installation(instance) or self._require_upgrade(instance):
             return self._dependencies_available(instance)
 
         return True
@@ -447,11 +447,11 @@ class RepoElementBuilderService(
         """Compute the derivative resources for a new instance.
 
         The hook is called only for new instances. An element that is already
-        installed when the builder registers it must be installed here: the
-        update path is never taken for it, because the instance is marked as
-        tracked right after the resource creation.
+        installed, or is an upgrade target, when the builder registers it must
+        be installed here: the update path is never taken for it, because the
+        instance is marked as tracked right after the resource creation.
         """
-        if self._require_installation(instance):
+        if self._require_installation(instance) or self._require_upgrade(instance):
             return [self._install_manifest(instance)]
 
         return ()

--- a/exordos_core/tests/functional/service/test_repo_builder.py
+++ b/exordos_core/tests/functional/service/test_repo_builder.py
@@ -96,6 +96,26 @@ def bootstrap_repo(manifests_dir, user_api):
 
 
 @pytest.fixture
+def bootstrap_repo_upgrade(manifests_dir, user_api):
+    """Create a Repository with two versions of the same element."""
+    _write_manifest(manifests_dir, "core", "1.0.0")
+    _write_manifest(manifests_dir, "core", "1.1.0")
+
+    repo = repo_builder.Repository(
+        name="test-repo-upgrade",
+        description="Test upgrade repository",
+        project_id=c.ZERO_UUID,
+        status=ua_c.InstanceStatus.NEW.value,
+        sync_mode=repo_models.SyncMode.COPY.value,
+        driver_spec=repo_models.BootstrapDriverSpec(
+            manifests_dir=manifests_dir,
+        ),
+    )
+    repo.insert()
+    return repo
+
+
+@pytest.fixture
 def bootstrap_repo_lazy(manifests_dir, user_api):
     """Create a Repository (builder version) in LAZY sync mode."""
     _write_manifest(manifests_dir, "core", "1.0.0")
@@ -729,3 +749,121 @@ class TestRepoElementBuilderService:
 
         assert len(result) == 0
         assert core.status == repo_models.RepoElementStatus.AVAILABLE.value
+
+    def _make_element_link(self, repo_element, tmp_path):
+        """Create a real EM element for the repo element and link it."""
+        from unittest import mock
+
+        from gcl_sdk.agents.universal.dm import models as ua_models
+        from gcl_sdk.agents.universal.storage import fs
+
+        from exordos_core.repo.agents.universal.drivers import (
+            repo_element as repo_element_driver,
+        )
+
+        storage = fs.TargetFieldsFileStorage(
+            os.path.join(str(tmp_path), "target_fields.json")
+        )
+        backend_client = repo_element_driver.RepoEmBackendClient(tf_storage=storage)
+
+        installed = element_builder.InstalledManifest.from_repo_element(repo_element)
+        resource = ua_models.Resource.from_value(
+            installed.dump_to_simple_view(),
+            kind=repo_element_driver.KIND,
+        )
+        with mock.patch(
+            "exordos_core.elements.dm.models.element_engine"
+        ) as mock_engine:
+            mock_engine.load_from_database.return_value = None
+            mock_engine.add_element.return_value = None
+            result = backend_client.create(resource)
+
+        repo_element.element = result.element
+        repo_element.update()
+        return repo_element
+
+    def _get_core(self, repo, version):
+        return repo_models.RepoElement.objects.get_one(
+            filters={
+                "repository": repo.uuid,
+                "name": dm_filters.EQ("core"),
+                "version": dm_filters.EQ(version),
+            },
+        )
+
+    def _installed_derivatives(self, uuid):
+        from gcl_sdk.agents.universal.dm import models as ua_models
+
+        return ua_models.TargetResource.objects.get_all(
+            filters={
+                "uuid": dm_filters.EQ(uuid),
+                "kind": dm_filters.EQ(
+                    element_builder.InstalledManifest.get_resource_kind()
+                ),
+            },
+        )
+
+    def test_upgrade_element_via_iteration(self, bootstrap_repo_upgrade, tmp_path):
+        """Upgrading a registered element should install the target version."""
+        repo_service = repo_builder.RepoProxyBuilderService()
+        repo_service._iteration()
+
+        # First iteration: registers the elements, sets AVAILABLE
+        self._service._iteration()
+
+        v1 = self._get_core(bootstrap_repo_upgrade, "1.0.0")
+        v2 = self._get_core(bootstrap_repo_upgrade, "1.1.0")
+
+        v1.installation_state = repo_models.RepoElementInstallationState.INSTALLED.value
+        v1.update()
+
+        # Second iteration: installs v1
+        self._service._iteration()
+        self._make_element_link(
+            self._get_core(bootstrap_repo_upgrade, "1.0.0"), tmp_path
+        )
+
+        self._get_core(bootstrap_repo_upgrade, "1.0.0").upgrade(target=str(v2.uuid))
+
+        # The iteration that must install the target version
+        self._service._iteration()
+
+        updated = self._get_core(bootstrap_repo_upgrade, "1.1.0")
+        assert updated.status == repo_models.RepoElementStatus.IN_PROGRESS.value
+        assert len(self._installed_derivatives(v2.uuid)) == 1
+
+    def test_upgrade_element_before_first_iteration(
+        self, manifests_dir, bootstrap_repo, tmp_path
+    ):
+        """An upgrade target marked installed before registration must install.
+
+        The upgrade request may arrive between the repository sync that
+        discovers the new version and the first element builder iteration for
+        it. Such an element goes through the create path, not the update one.
+        """
+        repo_service = repo_builder.RepoProxyBuilderService()
+        repo_service._iteration()
+
+        # Register the known elements and install core 1.0.0
+        self._service._iteration()
+        v1 = self._get_core(bootstrap_repo, "1.0.0")
+        v1.installation_state = repo_models.RepoElementInstallationState.INSTALLED.value
+        v1.update()
+        self._service._iteration()
+        self._make_element_link(self._get_core(bootstrap_repo, "1.0.0"), tmp_path)
+
+        # A new version appears in the repository
+        _write_manifest(manifests_dir, "core", "2.0.0")
+        repo_models.Repository.__driver_map__.clear()
+        repo_service._refresh_repository(bootstrap_repo)
+        v2 = self._get_core(bootstrap_repo, "2.0.0")
+
+        # The upgrade request arrives before the builder registers v2
+        self._get_core(bootstrap_repo, "1.0.0").upgrade(target=str(v2.uuid))
+
+        # The only iteration for v2: it takes the create path
+        self._service._iteration()
+
+        updated = self._get_core(bootstrap_repo, "2.0.0")
+        assert updated.status == repo_models.RepoElementStatus.IN_PROGRESS.value
+        assert len(self._installed_derivatives(v2.uuid)) == 1

--- a/exordos_core/tests/unit/repo/test_element_builder.py
+++ b/exordos_core/tests/unit/repo/test_element_builder.py
@@ -541,6 +541,35 @@ class TestCreateInstanceHooks:
         assert self._service.can_create_instance_resource(element) is False
         assert element.status == models.RepoElementStatus.ERROR.value
 
+    def test_create_derivatives_installs_upgrade_target(self, monkeypatch):
+        element = FakeElement(
+            installation_state=models.RepoElementInstallationState.INSTALLED.value,
+            element=sys_uuid.uuid4(),
+        )
+        manifest = object()
+        monkeypatch.setattr(self._service, "_install_manifest", lambda i: manifest)
+
+        result = self._service.create_instance_derivatives(element)
+
+        assert list(result) == [manifest]
+
+    def test_can_create_validates_dependencies_of_upgrade_target(self, monkeypatch):
+        element = FakeElement(
+            installation_state=models.RepoElementInstallationState.INSTALLED.value,
+            element=sys_uuid.uuid4(),
+        )
+
+        def _raise(instance):
+            raise repo_exceptions.DependencyNotFoundError(
+                name="dep",
+                element=instance.name,
+            )
+
+        monkeypatch.setattr(self._service, "_collect_dependencies", _raise)
+
+        assert self._service.can_create_instance_resource(element) is False
+        assert element.status == models.RepoElementStatus.ERROR.value
+
     def test_post_create_keeps_status_of_installed_element(self):
         element = FakeElement()
         element.status = models.RepoElementStatus.IN_PROGRESS.value


### PR DESCRIPTION
## Summary

An element upgrade requested shortly after a repository sync silently did
nothing: the target version stayed `AVAILABLE` and the element kept running the
previous version forever. This is the upgrade twin of #630, which fixed the same
race for a fresh installation but left the upgrade case open.

The target of an upgrade carries the runtime element (`RepoElement.upgrade()`
transfers it), so `_require_installation` is false and `_require_upgrade` is
true. The create path only handled `_require_installation`, so when the builder
registered the target version it produced no `InstalledManifest` derivative and
pinned the status to `AVAILABLE`. The instance is marked as tracked right after
the resource creation, so the update path never ran either. The old version in
turn blocks in `_require_release`, waiting for the pending element's
`InstalledManifest` that is never created.

Observed on a stand as `core` staying on 0.2.27 after `exordos e e update core`:

```text
core 0.2.27  status ACTIVE     installation UNINSTALLED   <- old, waiting to be released
core 0.2.28  status AVAILABLE  installation INSTALLED     <- target, never installed
```

with no 0.2.28 element in EM at all.

## Changes

- Handle `_require_upgrade` alongside `_require_installation` in
  `create_instance_derivatives` and `can_create_instance_resource`
- Functional test reproducing the race: a new version appears through a
  repository refresh, the upgrade is requested, and the builder's only
  iteration for the target takes the create path
- Functional test for the ordinary upgrade of an already registered element
- Unit tests for both create hooks with an upgrade target

## Verification

- `.tox/py314-functional/bin/python -m pytest exordos_core/tests/unit/repo
  exordos_core/tests/functional/service exordos_core/tests/functional/restapi/repo`
  — 231 passed. The new functional test fails on master with
  `assert 'AVAILABLE' == 'IN_PROGRESS'`.
- `ruff check exordos_core` — clean; `ruff format --check` clean for the touched
  files (`cmd/bootstrap.py` and `tests/unit/cmd/test_bootstrap_ua_config.py` are
  unformatted on master already and are not touched here).
- Not verified on a stand: the `core_update_tests` job in `exordos_tests` is the
  end-to-end check for this and should be re-run against a build with this fix.

## Summary by Sourcery

Install upgrade targets through the create path when they are already marked for installation at registration time.

Bug Fixes:
- Ensure upgrade targets are installed when they are registered after an upgrade request, preventing them from remaining AVAILABLE indefinitely.

Tests:
- Add functional coverage for upgrades requested before and after target registration, plus unit coverage for upgrade-target creation hooks.